### PR TITLE
Added getAllMembers Endpoint

### DIFF
--- a/apps/backend/src/users/types.ts
+++ b/apps/backend/src/users/types.ts
@@ -1,0 +1,7 @@
+export enum Status {
+  MEMBER = 'MEMBER',
+  RECRUITER = 'RECRUITER',
+  ADMIN = 'ADMIN',
+  ALUMNI = 'ALUMNI',
+  APPLICANT = 'APPLICANT',
+}

--- a/apps/backend/src/users/user.entity.ts
+++ b/apps/backend/src/users/user.entity.ts
@@ -1,9 +1,9 @@
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { Entity, Column, ObjectIdColumn } from 'typeorm';
 import { Status } from './types';
 
 @Entity()
 export class User {
-  @PrimaryGeneratedColumn()
+  @ObjectIdColumn() // https://github.com/typeorm/typeorm/issues/1584
   userId: number;
 
   @Column()

--- a/apps/backend/src/users/user.entity.ts
+++ b/apps/backend/src/users/user.entity.ts
@@ -1,10 +1,9 @@
-import { Entity, Column, ObjectIdColumn } from 'typeorm';
+import { Entity, Column, ObjectIdColumn, ObjectId } from 'typeorm';
 import { Status } from './types';
-
 @Entity()
 export class User {
   @ObjectIdColumn() // https://github.com/typeorm/typeorm/issues/1584
-  userId: number;
+  userId: ObjectId;
 
   @Column()
   status: Status;

--- a/apps/backend/src/users/user.entity.ts
+++ b/apps/backend/src/users/user.entity.ts
@@ -1,9 +1,13 @@
 import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { Status } from './types';
 
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
-  id: number;
+  userId: number;
+
+  @Column()
+  status: Status;
 
   @Column()
   firstName: string;
@@ -13,4 +17,19 @@ export class User {
 
   @Column()
   email: string;
+
+  @Column()
+  profilePicture: string;
+
+  @Column()
+  linkedin: string | null;
+
+  @Column()
+  github: string | null;
+
+  @Column()
+  team: string | null;
+
+  @Column()
+  role: string | null;
 }

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  DefaultValuePipe,
+  ParseBoolPipe,
+  Query,
+  Controller,
+  Get,
+} from '@nestjs/common';
 
 import { UsersService } from './users.service';
 
@@ -7,7 +13,10 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get()
-  getAllUsers() {
-    return this.usersService.findAll();
+  getAllMembers(
+    @Query('getAllMembers', new DefaultValuePipe(false), ParseBoolPipe)
+    getAllMembers: boolean,
+  ) {
+    return this.usersService.findAll(getAllMembers);
   }
 }

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadRequestException,
-  UnauthorizedException,
-  Injectable,
-} from '@nestjs/common';
+import { UnauthorizedException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MongoRepository } from 'typeorm';
 

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -8,6 +8,7 @@ import { MongoRepository } from 'typeorm';
 
 import { User } from './user.entity';
 import { Status } from './types';
+import { ObjectId } from 'mongodb';
 
 @Injectable()
 export class UsersService {
@@ -20,7 +21,7 @@ export class UsersService {
     if (!getAllMembers) return [];
 
     const exampleUser: User = {
-      userId: 1,
+      userId: new ObjectId('a0f3efa0f3efa0f3efa0f3ef'),
       status: Status.ADMIN,
       firstName: 'jimmy',
       lastName: 'jimmy2',

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -43,13 +43,6 @@ export class UsersService {
       },
     });
 
-    //TODO possibly use an interceptor instead here
-    users.forEach((user: User) => {
-      if (user.status == Status.APPLICANT) {
-        throw new BadRequestException();
-      }
-    });
-
     return users;
   }
 }

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -1,8 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  UnauthorizedException,
+  Injectable,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { User } from './user.entity';
+import { Status } from './types';
 
 @Injectable()
 export class UsersService {
@@ -11,7 +16,35 @@ export class UsersService {
     private usersRepository: Repository<User>,
   ) {}
 
-  findAll(): Promise<User[]> {
-    return this.usersRepository.find();
+  async findAll(getAllMembers: boolean): Promise<User[]> {
+    if (!getAllMembers) return [];
+
+    const exampleUser: User = {
+      userId: 1,
+      status: Status.ADMIN,
+      firstName: 'jimmy',
+      lastName: 'jimmy2',
+      email: 'jimmy.jimmy2@mail.com',
+      profilePicture: null,
+      linkedin: null,
+      github: null,
+      team: null,
+      role: null,
+    };
+
+    if (exampleUser.status == Status.APPLICANT) {
+      throw new UnauthorizedException();
+    }
+
+    const users: User[] = await this.usersRepository.find();
+
+    //TODO possibly use an interceptor instead here
+    users.forEach((user: User) => {
+      if (user.status == Status.APPLICANT) {
+        throw new BadRequestException();
+      }
+    });
+
+    return users;
   }
 }

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -4,7 +4,7 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { MongoRepository } from 'typeorm';
 
 import { User } from './user.entity';
 import { Status } from './types';
@@ -13,7 +13,7 @@ import { Status } from './types';
 export class UsersService {
   constructor(
     @InjectRepository(User)
-    private usersRepository: Repository<User>,
+    private usersRepository: MongoRepository<User>,
   ) {}
 
   async findAll(getAllMembers: boolean): Promise<User[]> {
@@ -36,7 +36,11 @@ export class UsersService {
       throw new UnauthorizedException();
     }
 
-    const users: User[] = await this.usersRepository.find();
+    const users: User[] = await this.usersRepository.find({
+      where: {
+        status: { $not: { $eq: Status.APPLICANT } },
+      },
+    });
 
     //TODO possibly use an interceptor instead here
     users.forEach((user: User) => {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "format:check": "prettier --check apps/{frontend,backend}/src/**/*.{ts,tsx}",
-    "format": "prettier --write apps/{frontend,backend}/src/**/*.{ts,tsx}",
+    "format:check": "prettier --no-error-on-unmatched-pattern --check apps/{frontend,backend}/src/**/*.{js,ts,tsx}",
+    "format": "prettier --no-error-on-unmatched-pattern --write apps/{frontend,backend}/src/**/*.{js,ts,tsx}",
     "lint:check": "eslint apps/frontend --ext .ts,.tsx && eslint apps/backend --ext .ts,.tsx",
     "lint": "eslint apps/frontend --ext .ts,.tsx --fix && eslint apps/backend --ext .ts,.tsx --fix",
     "prepush": "yarn run format:check && yarn run lint:check",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "format:check": "prettier --check apps/{frontend,backend}/src/**/*.{js,ts,tsx}",
-    "format": "prettier --write apps/{frontend,backend}/src/**/*.{js,ts,tsx}",
+    "format:check": "prettier --check apps/{frontend,backend}/src/**/*.{ts,tsx}",
+    "format": "prettier --write apps/{frontend,backend}/src/**/*.{ts,tsx}",
     "lint:check": "eslint apps/frontend --ext .ts,.tsx && eslint apps/backend --ext .ts,.tsx",
     "lint": "eslint apps/frontend --ext .ts,.tsx --fix && eslint apps/backend --ext .ts,.tsx --fix",
     "prepush": "yarn run format:check && yarn run lint:check",


### PR DESCRIPTION
### ℹ️ Issue

Closes #3 

### 📝 Description
Added an endpoint where C4C members can get access to the information of all members and alumni in C4C. All C4C-affilitated members (regular members, recruiters, alumni, admins) have permission to call this endpoint. Applicants are not permitted.

Code Changes:
- Updated user controller and service to handle the new endpoint. The service makes usage of nest.js pipes to transform the incoming request parameter into the expected Boolean format.
- Created a fake user in the service to mimic endpoint caller permissions. This is to ensure that the endpoint rejects applicants from calling it.
- Created an enum to represent different user statuses to handle authorization.
- Renamed the user entity's "id" primary key to "userId" and swapped @PrimaryGeneratedColumn with @ObjectIdColumn as per https://typeorm.io/mongodb and https://github.com/typeorm/typeorm/issues/1584
- Changed UserRepository to MongoRepository to support native MongoDB operators (https://www.mongodb.com/docs/manual/reference/operator/query/) as shown in https://typeorm.io/mongodb

### ✔️ Verification
Created a local MongoDB database "c4cOpsTest" with multiple example users. Ensured that at least one user had an "applicant" status. Checked for expected behavior in the following scenarios:
- Pass in no query parameter (should default to false and return an empty list)
- Pass in ?getAllMembers=true (should return all members with no applicants)
- Pass in ?getAllMembers=false (should return an empty list)
- Pass in a garbage query parameter value ?getAllMembers=foo (should throw an exception)
- Change status of fake user to "applicant" (should throw a 401 exception)

### 🏕️ (Optional) Future Work / Notes
- Consider making the check (are any of the returned users applicants?) a generic interceptor to separate concerns
- Update the fake user with authentication
