### PR TITLE
Made changes to domain checks

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -15,7 +15,7 @@ import { ApplicationsModule } from './applications/applications.module';
       type: 'postgres',
       database: 'c4c-ops',
       host: process.env.NX_DB_HOST,
-      port: 5433,
+      port: 5432,
       username: process.env.NX_DB_USERNAME,
       password: process.env.NX_DB_PASSWORD,
       autoLoadEntities: true,

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -13,8 +13,9 @@ import { ApplicationsModule } from './applications/applications.module';
   imports: [
     TypeOrmModule.forRoot({
       type: 'postgres',
+      database: 'c4c-ops',
       host: process.env.NX_DB_HOST,
-      port: 5432,
+      port: 5433,
       username: process.env.NX_DB_USERNAME,
       password: process.env.NX_DB_PASSWORD,
       autoLoadEntities: true,

--- a/apps/backend/src/auth/auth.controller.spec.ts
+++ b/apps/backend/src/auth/auth.controller.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { omit } from 'lodash';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { userFactory } from '../testing/factories/user.factory';
+import { UsersService } from '../users/users.service';
+
+const mockAuthService: Partial<AuthService> = {
+  signup: jest.fn(),
+};
+
+const mockUsersService: Partial<UsersService> = {
+  create: jest.fn(),
+};
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: mockAuthService,
+        },
+        // {
+        //   provide: getRepositoryToken(User),
+        //   useValue: {},
+        // },
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('signUp', () => {
+    it('should add a new user with either northeastern.edu or husky.neu.edu email', async () => {
+      jest.spyOn(mockAuthService, 'signup').mockResolvedValue(undefined);
+
+      await expect(
+        controller.createUser({
+          firstName: 'Ahnaf',
+          lastName: 'Inkiad',
+          email: 'inkiad.a@northeastern.edu',
+          password: 'Password1!',
+        }),
+      ).resolves.not.toThrow(
+        'Invalid email domain. Only northeastern.edu and husky.neu.edu domains are allowed.',
+      );
+    });
+
+    describe('signUp', () => {
+      it('should throw an error because of not having northeastern.edu or husky.neu.edu email', async () => {
+        jest.spyOn(mockAuthService, 'signup').mockResolvedValue(undefined);
+
+        await expect(
+          controller.createUser({
+            firstName: 'Ahnaf',
+            lastName: 'Inkiad',
+            email: 'inkiad.a@nnnnortheastern.edu',
+            password: 'Password1!',
+          }),
+        ).rejects.toThrow(
+          'Invalid email domain. Only northeastern.edu and husky.neu.edu domains are allowed.',
+        );
+      });
+    });
+
+    // it("should throw an error if the user can't be found", async () => {
+    //   const errorMessge = 'Cannot find user';
+
+    //   jest
+    //     .spyOn(mockUsersService, 'findOne')
+    //     .mockRejectedValue(new Error(errorMessge));
+
+    //   expect(controller.getUser(2, defaultUser)).rejects.toThrow(errorMessge);
+    // });
+  });
+});

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -30,6 +30,16 @@ export class AuthController {
 
   @Post('/signup')
   async createUser(@Body() signUpDto: SignUpRequestDTO): Promise<User> {
+    //Regular expression to validate the email domain
+    const domainRegex = /@(northeastern\.edu|husky\.neu\.edu)$/;
+
+    //Check if the email domain is valid
+    if (!domainRegex.test(signUpDto.email)) {
+      throw new BadRequestException(
+        'Invalid email domain. Only northeastern.edu and husky.neu.edu domains are allowed.',
+      );
+    }
+
     try {
       await this.authService.signup(signUpDto);
     } catch (e) {

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -24,10 +24,6 @@ export class AuthService {
   private readonly providerClient: CognitoIdentityProviderClient;
 
   constructor() {
-    console.log(CognitoAuthConfig.userPoolId);
-    console.log(CognitoAuthConfig.clientId);
-    console.log(process.env.NX_BASE);
-    console.log(process.env.NX_API_URL);
     this.userPool = new CognitoUserPool({
       UserPoolId: CognitoAuthConfig.userPoolId,
       ClientId: CognitoAuthConfig.clientId,

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -24,6 +24,10 @@ export class AuthService {
   private readonly providerClient: CognitoIdentityProviderClient;
 
   constructor() {
+    console.log(CognitoAuthConfig.userPoolId);
+    console.log(CognitoAuthConfig.clientId);
+    console.log(process.env.NX_BASE);
+    console.log(process.env.NX_API_URL);
     this.userPool = new CognitoUserPool({
       UserPoolId: CognitoAuthConfig.userPoolId,
       ClientId: CognitoAuthConfig.clientId,


### PR DESCRIPTION
### ℹ️ Issue

Closes #35 

### Previously, if someone wanted to signup, they could sign up with any email. But now with domain checks, only emails with northeastern.edu or husky.neu.edu will be allowed to signup, other emails will throw an error if someone wants to signup.


Briefly list the changes made to the code:
1. Added a domain check to auth.controller.ts


### ✔️ Verification

Manually verified using Postman for both valid and invalid email, and also wrote unit tests in the auth.controller.spec.ts for both valid and invalid cases.




