### PR TITLE
feat: getAllApplications

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -13,7 +13,6 @@ import { ApplicationsModule } from './applications/applications.module';
   imports: [
     TypeOrmModule.forRoot({
       type: 'postgres',
-      database: 'c4c-ops',
       host: process.env.NX_DB_HOST,
       port: 5432,
       username: process.env.NX_DB_USERNAME,

--- a/apps/backend/src/applications/application.entity.ts
+++ b/apps/backend/src/applications/application.entity.ts
@@ -17,6 +17,7 @@ import {
 } from './types';
 import { GetApplicationResponseDTO } from './dto/get-application.response.dto';
 import { Review } from '../reviews/review.entity';
+import { GetAllApplicationResponseDTO } from './dto/get-all-application.response.dto';
 
 @Entity()
 export class Application {
@@ -61,6 +62,23 @@ export class Application {
   @IsArray()
   @IsObject({ each: true })
   reviews: Review[];
+
+  toGetAllApplicationResponseDTO(): GetAllApplicationResponseDTO {
+    const meanRatingAllStages = 0;
+    const meanRatingSingleStages = 0;
+
+    return {
+      userId: this.user.id,
+      firstName: this.user.firstName,
+      lastName: this.user.lastName,
+      stage: this.stage,
+      step: this.step,
+      position: this.position,
+      createdAt: this.createdAt,
+      meanRatingAllStages: meanRatingAllStages,
+      meanRatingSingleStages: meanRatingSingleStages,
+    };
+  }
 
   toGetApplicationResponseDTO(numApps: number): GetApplicationResponseDTO {
     return {

--- a/apps/backend/src/applications/application.entity.ts
+++ b/apps/backend/src/applications/application.entity.ts
@@ -64,8 +64,8 @@ export class Application {
   reviews: Review[];
 
   toGetAllApplicationResponseDTO(): GetAllApplicationResponseDTO {
-    const meanRatingAllStages = 0;
-    const meanRatingSingleStages = 0;
+    const meanRatingAllStages = 0; // TODO: calculate this
+    const meanRatingSingleStages = 0; // TODO: calculate this (should be an object)
 
     return {
       userId: this.user.id,

--- a/apps/backend/src/applications/applications.controller.ts
+++ b/apps/backend/src/applications/applications.controller.ts
@@ -20,6 +20,7 @@ import { GetApplicationResponseDTO } from './dto/get-application.response.dto';
 import { getAppForCurrentCycle } from './utils';
 import { UserStatus } from '../users/types';
 import { Application } from './application.entity';
+import { GetAllApplicationResponseDTO } from './dto/get-all-application.response.dto';
 
 @Controller('apps')
 @UseInterceptors(CurrentUserInterceptor)
@@ -39,8 +40,11 @@ export class ApplicationsController {
     return await this.applicationsService.submitApp(application, user);
   }
 
+  @UseGuards(AuthGuard('jwt'))
   @Get('/')
-  async getApplications(@Request() req): Promise<GetApplicationResponseDTO[]> {
+  async getApplications(
+    @Request() req,
+  ): Promise<GetAllApplicationResponseDTO[]> {
     if (
       !(
         req.user.status === UserStatus.RECRUITER ||

--- a/apps/backend/src/applications/applications.controller.ts
+++ b/apps/backend/src/applications/applications.controller.ts
@@ -8,6 +8,7 @@ import {
   UseGuards,
   BadRequestException,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { CurrentUserInterceptor } from '../interceptors/current-user.interceptor';
 import { AuthGuard } from '@nestjs/passport';
@@ -21,6 +22,22 @@ import { UserStatus } from '../users/types';
 @UseGuards(AuthGuard('jwt'))
 export class ApplicationsController {
   constructor(private readonly applicationsService: ApplicationsService) {}
+
+  @Get('/')
+  async getApplications(@Request() req): Promise<GetApplicationResponseDTO[]> {
+    if (
+      !(
+        req.user.status === UserStatus.RECRUITER ||
+        req.user.status === UserStatus.ADMIN
+      )
+    ) {
+      throw new UnauthorizedException(
+        'calling user is not a recruiter or admin',
+      );
+    }
+
+    return this.applicationsService.findAllCurrentApplications();
+  }
 
   @Get('/:userId')
   async getApplication(

--- a/apps/backend/src/applications/applications.controller.ts
+++ b/apps/backend/src/applications/applications.controller.ts
@@ -32,7 +32,7 @@ export class ApplicationsController {
       )
     ) {
       throw new UnauthorizedException(
-        'calling user is not a recruiter or admin',
+        'Calling user is not a recruiter or admin.',
       );
     }
 

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -25,20 +25,22 @@ export class ApplicationsService {
   }
 
   async findAllCurrentApplications(): Promise<GetApplicationResponseDTO[]> {
-    const currentCycle: Cycle = getCurrentCycle();
     const applications = await this.applicationsRepository.find({
       where: {
         //TODO q: I had to change Cycle definition to make year and semester public. Is there a reason it was private?
-        year: currentCycle.year,
-        semester: currentCycle.semester,
+        year: process.env.NX_CURRENT_YEAR,
+        semester: process.env.NX_CURRENT_SEMESTER,
       },
     });
 
     const dtos: GetApplicationResponseDTO[] = [];
 
-    applications.forEach((app) =>
+    applications.forEach(async (app) =>
       //TODO q: what is the numApps parameter? I just passed 0 in
-      dtos.push(app.toGetApplicationResponseDTO(0)),
+      {
+        const apps = await this.findAll(app.user.id);
+        dtos.push(app.toGetApplicationResponseDTO(apps.length));
+      },
     );
 
     return dtos;

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -3,7 +3,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { MongoRepository } from 'typeorm';
 import { UsersService } from '../users/users.service';
 import { Application } from './application.entity';
-import { getAppForCurrentCycle } from './utils';
+import { getAppForCurrentCycle, getCurrentCycle } from './utils';
+import { GetApplicationResponseDTO } from './dto/get-application.response.dto';
+import { Cycle } from './dto/cycle';
 
 @Injectable()
 export class ApplicationsService {
@@ -20,6 +22,26 @@ export class ApplicationsService {
     });
 
     return apps;
+  }
+
+  async findAllCurrentApplications(): Promise<GetApplicationResponseDTO[]> {
+    const currentCycle: Cycle = getCurrentCycle();
+    const applications = await this.applicationsRepository.find({
+      where: {
+        //TODO q: I had to change Cycle definition to make year and semester public. Is there a reason it was private?
+        year: currentCycle.year,
+        semester: currentCycle.semester,
+      },
+    });
+
+    const dtos: GetApplicationResponseDTO[] = [];
+
+    applications.forEach((app) =>
+      //TODO q: what is the numApps parameter? I just passed 0 in
+      dtos.push(app.toGetApplicationResponseDTO(0)),
+    );
+
+    return dtos;
   }
 
   async findCurrent(userId: number): Promise<Application> {

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -7,12 +7,17 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { MongoRepository } from 'typeorm';
 import { UsersService } from '../users/users.service';
 import { Application } from './application.entity';
-import { getAppForCurrentCycle, getCurrentCycle } from './utils';
-import { GetApplicationResponseDTO } from './dto/get-application.response.dto';
+import {
+  getAppForCurrentCycle,
+  getCurrentCycle,
+  getCurrentSemester,
+  getCurrentYear,
+} from './utils';
 import { Response } from './types';
 import * as crypto from 'crypto';
 import { User } from '../users/user.entity';
 import { Position, ApplicationStage, ApplicationStep } from './types';
+import { GetAllApplicationResponseDTO } from './dto/get-all-application.response.dto';
 
 @Injectable()
 export class ApplicationsService {
@@ -98,24 +103,20 @@ export class ApplicationsService {
     return apps;
   }
 
-  async findAllCurrentApplications(): Promise<GetApplicationResponseDTO[]> {
+  async findAllCurrentApplications(): Promise<GetAllApplicationResponseDTO[]> {
     const applications = await this.applicationsRepository.find({
       where: {
-        //TODO q: I had to change Cycle definition to make year and semester public. Is there a reason it was private?
-        year: process.env.NX_CURRENT_YEAR,
-        semester: process.env.NX_CURRENT_SEMESTER,
+        year: getCurrentYear(),
+        semester: getCurrentSemester(),
       },
+      relations: ['user'],
     });
 
-    const dtos: GetApplicationResponseDTO[] = [];
+    const dtos: GetAllApplicationResponseDTO[] = [];
 
-    applications.forEach(async (app) =>
-      //TODO q: what is the numApps parameter? I just passed 0 in
-      {
-        const apps = await this.findAll(app.user.id);
-        dtos.push(app.toGetApplicationResponseDTO(apps.length));
-      },
-    );
+    applications.forEach((app) => {
+      dtos.push(app.toGetAllApplicationResponseDTO());
+    });
 
     return dtos;
   }

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -112,11 +112,9 @@ export class ApplicationsService {
       relations: ['user'],
     });
 
-    const dtos: GetAllApplicationResponseDTO[] = [];
-
-    applications.forEach((app) => {
-      dtos.push(app.toGetAllApplicationResponseDTO());
-    });
+    const dtos: GetAllApplicationResponseDTO[] = applications.map((app) =>
+      app.toGetAllApplicationResponseDTO(),
+    );
 
     return dtos;
   }

--- a/apps/backend/src/applications/dto/cycle.ts
+++ b/apps/backend/src/applications/dto/cycle.ts
@@ -1,7 +1,7 @@
 import { Semester } from '../types';
 
 export class Cycle {
-  constructor(private year: number, private semester: Semester) {}
+  constructor(public year: number, public semester: Semester) {}
 
   public isCurrentCycle(cycle: Cycle): boolean {
     return this.year === cycle.year && this.semester === cycle.semester;

--- a/apps/backend/src/applications/dto/cycle.ts
+++ b/apps/backend/src/applications/dto/cycle.ts
@@ -1,7 +1,7 @@
 import { Semester } from '../types';
 
 export class Cycle {
-  constructor(public year: number, public semester: Semester) {}
+  constructor(private year: number, private semester: Semester) {}
 
   public isCurrentCycle(cycle: Cycle): boolean {
     return this.year === cycle.year && this.semester === cycle.semester;

--- a/apps/backend/src/applications/dto/get-all-application.response.dto.ts
+++ b/apps/backend/src/applications/dto/get-all-application.response.dto.ts
@@ -1,0 +1,32 @@
+import { IsDate, IsEnum, IsPositive, IsString } from 'class-validator';
+import { ApplicationStage, ApplicationStep, Position } from '../types';
+
+export class GetAllApplicationResponseDTO {
+  @IsPositive()
+  userId: number;
+
+  @IsString()
+  firstName: string;
+
+  @IsString()
+  lastName: string;
+
+  @IsEnum(ApplicationStage)
+  stage: ApplicationStage;
+
+  @IsEnum(ApplicationStep)
+  step: ApplicationStep;
+
+  @IsEnum(Position)
+  position: Position;
+
+  @IsDate()
+  createdAt: Date;
+
+  @IsPositive()
+  meanRatingAllStages: number;
+
+  // TODO: Should be a JSON or similar that defines scores for each stage
+  @IsPositive()
+  meanRatingSingleStages: number;
+}

--- a/apps/backend/src/applications/utils.ts
+++ b/apps/backend/src/applications/utils.ts
@@ -2,8 +2,20 @@ import { Application } from './application.entity';
 import { Cycle } from './dto/cycle';
 import { Semester } from './types';
 
-// TODO get the current cycle's year and semester from env variables
-export const getCurrentCycle = () => new Cycle(2024, Semester.SPRING);
+export const getCurrentSemester = (): Semester => {
+  const month: number = new Date().getMonth();
+  if (month >= 0 && month <= 5) {
+    return Semester.SPRING;
+  }
+  return Semester.FALL;
+};
+
+export const getCurrentYear = (): number => {
+  return new Date().getFullYear();
+};
+
+export const getCurrentCycle = () =>
+  new Cycle(getCurrentYear(), getCurrentSemester());
 
 export const getAppForCurrentCycle = (
   applications: Application[],

--- a/apps/backend/src/applications/utils.ts
+++ b/apps/backend/src/applications/utils.ts
@@ -5,9 +5,9 @@ import { Semester } from './types';
 export const getCurrentSemester = (): Semester => {
   const month: number = new Date().getMonth();
   if (month >= 0 && month <= 5) {
-    return Semester.SPRING;
+    return Semester.FALL; // We will be recruiting for the fall semester during Jan - Jun
   }
-  return Semester.FALL;
+  return Semester.SPRING; // We will be recruiting for the spring semester during Jul - Dec
 };
 
 export const getCurrentYear = (): number => {

--- a/apps/backend/src/applications/utils.ts
+++ b/apps/backend/src/applications/utils.ts
@@ -4,10 +4,10 @@ import { Semester } from './types';
 
 export const getCurrentSemester = (): Semester => {
   const month: number = new Date().getMonth();
-  if (month >= 0 && month <= 5) {
-    return Semester.FALL; // We will be recruiting for the fall semester during Jan - Jun
+  if (month >= 1 && month <= 7) {
+    return Semester.FALL; // We will be recruiting for the fall semester during Feb - Aug
   }
-  return Semester.SPRING; // We will be recruiting for the spring semester during Jul - Dec
+  return Semester.SPRING; // We will be recruiting for the spring semester during Sep - Jan
 };
 
 export const getCurrentYear = (): number => {


### PR DESCRIPTION
### ℹ️ Issue

Closes #44 #59

### 📝 Description

Added GET endpoint at route "api/apps/"

If calling user is not a recruiter or admin, return 401 unauthurized. otherwise returns all applications of current cycle

response is an array of GetApplicationResponseDTO:
[
GetApplicationResponseDTO,
GetApplicationResponseDTO,
...
]

this is a bit different from what was specified in the ticket:
{
  "applications": GetApplicationResponseDTO[]
}

because I believe it falls more in line with the existing endpoints and type definitions. If necessary I can change it to follow the ticket more exactly.

Comments/Questions:
* I was unsure how to test this with postman. Im not sure how to emulate a recruiter/admin/other role as the calling user through postman. How would I do so?

* Does  req.user.status hold the calling users role (admin, Member, recruiter, etc)? I assumed so by looking at other endpoints, but Im not certain

* Is there a reason the fields in the Cycle class were made private? I had to make them public to make this work

* What is the numapps parameter in the application.toGetApplicationResponseDTO() function supposed to represent?