### PR TITLE
Ry 89 applicant update own info

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -6,6 +6,7 @@
 import { Logger, ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { NestFactory } from '@nestjs/core';
+import { useContainer } from 'class-validator';
 
 import { AppModule } from './app.module';
 
@@ -19,8 +20,11 @@ async function bootstrap() {
     new ValidationPipe({
       transform: true,
       whitelist: true,
+      validateCustomDecorators: true,
     }),
   );
+
+  useContainer(app.select(AppModule), { fallbackOnErrors: true });
 
   const config = new DocumentBuilder()
     .setTitle('Scaffolding API Docs')

--- a/apps/backend/src/users/dto/update-user.request.dto.ts
+++ b/apps/backend/src/users/dto/update-user.request.dto.ts
@@ -10,6 +10,7 @@ import {
   IsUrl,
   IsObject,
 } from 'class-validator';
+import { IsEmailUnique } from '../email-unique.decorator';
 
 export class UpdateUserRequestDTO {
   @IsOptional()
@@ -18,6 +19,7 @@ export class UpdateUserRequestDTO {
 
   @IsOptional()
   @IsEmail()
+  @IsEmailUnique({ message: 'This email is already in use.' })
   email?: string;
 
   @IsOptional()

--- a/apps/backend/src/users/email-unique.decorator.ts
+++ b/apps/backend/src/users/email-unique.decorator.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { UsersService } from './users.service';
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  registerDecorator,
+  ValidationOptions,
+} from 'class-validator';
+
+@ValidatorConstraint({ async: true })
+@Injectable()
+export class IsEmailUniqueConstraint implements ValidatorConstraintInterface {
+  constructor(private usersService: UsersService) {}
+
+  async validate(email: string): Promise<boolean> {
+    const user = await this.usersService.findByEmail(email);
+    return user.length === 0;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return 'Email $value is already in use.';
+  }
+}
+
+export function IsEmailUnique(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsEmailUniqueConstraint,
+    });
+  };
+}

--- a/apps/backend/src/users/users.module.ts
+++ b/apps/backend/src/users/users.module.ts
@@ -6,11 +6,18 @@ import { User } from './user.entity';
 import { JwtStrategy } from '../auth/jwt.strategy';
 import { CurrentUserInterceptor } from '../interceptors/current-user.interceptor';
 import { AuthService } from '../auth/auth.service';
+import { IsEmailUniqueConstraint } from './email-unique.decorator';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   controllers: [UsersController],
-  providers: [UsersService, AuthService, JwtStrategy, CurrentUserInterceptor],
-  exports: [UsersService],
+  providers: [
+    UsersService,
+    AuthService,
+    JwtStrategy,
+    IsEmailUniqueConstraint,
+    CurrentUserInterceptor,
+  ],
+  exports: [UsersService, IsEmailUniqueConstraint],
 })
 export class UsersModule {}

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -16,6 +16,14 @@ type SubmitReviewRequest = {
   content: string;
 };
 
+type UpdateUserRequest = {
+  applicantId: number;
+  email?: string;
+  phoneNumber?: string;
+  linkedin?: string;
+  github?: string;
+};
+
 type DecisionRequest = { decision: 'ACCEPT' | 'REJECT' };
 
 export class ApiClient {
@@ -88,6 +96,18 @@ export class ApiClient {
     }) as Promise<User>;
   }
 
+  public async updateUser(
+    accessToken: string,
+    userId: number,
+    updatesData: Partial<UpdateUserRequest>,
+  ): Promise<void> {
+    return this.patch(`/api/users/${userId}`, updatesData, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }) as Promise<void>;
+  }
+
   private async get(
     path: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -120,9 +140,14 @@ export class ApiClient {
       .then((response) => response.data);
   }
 
-  private async patch(path: string, body: unknown): Promise<unknown> {
+  private async patch(
+    path: string,
+    body: unknown,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    headers: AxiosRequestConfig<any> | undefined = undefined,
+  ): Promise<unknown> {
     return this.axiosInstance
-      .patch(path, body)
+      .patch(path, body, headers)
       .then((response) => response.data);
   }
 

--- a/apps/frontend/src/components/ApplicantView/user.tsx
+++ b/apps/frontend/src/components/ApplicantView/user.tsx
@@ -8,6 +8,8 @@ import {
   ListItemText,
   Box,
   CircularProgress,
+  TextField,
+  Button,
 } from '@mui/material';
 import { DoneOutline } from '@mui/icons-material';
 import apiClient from '@api/apiClient';
@@ -24,6 +26,8 @@ export const ApplicantView = ({ user }: ApplicantViewProps) => {
     useState<Application | null>(null);
   const [fullName, setFullName] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
+  const [email, setEmail] = useState<string>(user.email || '');
+  const [editMode, setEditMode] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchApplication = async (userId: number) => {
@@ -50,6 +54,22 @@ export const ApplicantView = ({ user }: ApplicantViewProps) => {
     fetchApplication(user.id);
     fetchFullName();
   }, [accessToken, user.id]);
+
+  const handleUserUpdate = async () => {
+    try {
+      await apiClient.updateUser(accessToken, user.id, { email });
+      alert(
+        'Email updated successfully! Please close this tab and login using ' +
+          email +
+          ' in a new tab.',
+      );
+      setEditMode(false);
+    } catch (err) {
+      //  add better error message for invalid inputs
+      console.error('Error updating email:', err);
+      alert('Failed to update email.');
+    }
+  };
 
   return (
     <Box
@@ -170,6 +190,40 @@ export const ApplicantView = ({ user }: ApplicantViewProps) => {
                     </ListItem>
                   ))}
                 </List>
+                {/* Update Email Section */}
+                <Typography variant="h6" mt={3}>
+                  Contact Information
+                </Typography>
+
+                {editMode ? (
+                  <Box>
+                    <TextField
+                      label="Email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      fullWidth
+                      sx={{ mb: 2, backgroundColor: '#fff', borderRadius: 1 }}
+                    />
+                    <Button
+                      onClick={handleUserUpdate}
+                      variant="contained"
+                      color="primary"
+                    >
+                      Save
+                    </Button>
+                  </Box>
+                ) : (
+                  <Box>
+                    <Typography variant="body1">Email: {email}</Typography>
+                    <Button
+                      onClick={() => setEditMode(true)}
+                      variant="contained"
+                      color="secondary"
+                    >
+                      Update
+                    </Button>
+                  </Box>
+                )}
               </>
             )}
           </div>

--- a/apps/frontend/src/components/types.ts
+++ b/apps/frontend/src/components/types.ts
@@ -68,6 +68,7 @@ type Application = {
 type User = {
   id: number;
   status: string;
+  email: string;
 };
 
 export {


### PR DESCRIPTION
#89  ℹ️ Issue

Closes 89 

### 📝 Description

Added a button to allow applicants to update their email. 

Briefly list the changes made to the code:
1. Added a change contact information (email) button below the applicant information screen that allows applicants to change their own email. Once emails are changed alert the user to close the tab and log in in a new tab.
2. Added an email uniqueness verifier to the update email to verify that when updating to a new email there isn't already an application with the same email.

### ✔️ Verification
I verified my changes worked by going to the page and using the change email button that I added. I verified that I am able to change my email to one that doesn't already have an application. Then I also verified that once the email has been changed that email is now the new login and that logging in with that new email works. 



### 🏕️ (Optional) Future Work / Notes
Possibly add better notification messages for when the email fails to be updated.
