### PR TITLE
Refresh button, and butotn to 

### DIFF
--- a/apps/backend/src/applications/application.entity.ts
+++ b/apps/backend/src/applications/application.entity.ts
@@ -66,7 +66,7 @@ export class Application {
   @IsObject({ each: true })
   response: Response[];
 
-  @Column('varchar', { array: true, default: {} })
+  // @Column('varchar', { array: true, default: {} })
   @IsArray()
   @IsObject({ each: true })
   @OneToMany(() => Review, (review) => review.application)

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -3,6 +3,7 @@ import type {
   Application,
   ApplicationRow,
   ApplicationStage,
+  Decision,
   User,
 } from '@components/types';
 
@@ -16,7 +17,9 @@ type SubmitReviewRequest = {
   content: string;
 };
 
-type DecisionRequest = { decision: 'ACCEPT' | 'REJECT' };
+type DecisionRequest = {
+  decision: Decision;
+};
 
 export class ApiClient {
   private readonly axiosInstance: AxiosInstance;
@@ -67,6 +70,18 @@ export class ApiClient {
         Authorization: `Bearer ${accessToken}`,
       },
     })) as Promise<string>;
+  }
+
+  public async submitDecision(
+    accessToken: string,
+    userId: number,
+    decision: DecisionRequest,
+  ): Promise<void> {
+    return this.post(`/decision/${userId}`, decision, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }) as Promise<void>;
   }
 
   public async submitReview(

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -18,7 +18,7 @@ type SubmitReviewRequest = {
 };
 
 type DecisionRequest = {
-  decision: Decision;
+  decision: 'ACCEPT' | 'REJECT';
 };
 
 export class ApiClient {
@@ -75,9 +75,9 @@ export class ApiClient {
   public async submitDecision(
     accessToken: string,
     applicationId: number,
-    decision: DecisionRequest,
+    decisionRequest: DecisionRequest,
   ): Promise<void> {
-    return this.post(`/api/apps/decision/${applicationId}`, decision, {
+    return this.post(`/api/apps/decision/${applicationId}`, decisionRequest, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -74,10 +74,10 @@ export class ApiClient {
 
   public async submitDecision(
     accessToken: string,
-    userId: number,
+    applicationId: number,
     decision: DecisionRequest,
   ): Promise<void> {
-    return this.post(`/decision/${userId}`, decision, {
+    return this.post(`/api/apps/decision/${applicationId}`, decision, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },

--- a/apps/frontend/src/components/ApplicationTables/decisionModal.tsx
+++ b/apps/frontend/src/components/ApplicationTables/decisionModal.tsx
@@ -1,0 +1,92 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Stack,
+  Typography,
+  Rating,
+  TextField,
+  Button,
+  MenuItem,
+  Select,
+} from '@mui/material';
+import { useState } from 'react';
+import apiClient from '@api/apiClient';
+import {
+  Application,
+  ApplicationRow,
+  ApplicationStage,
+  Decision,
+} from '../types';
+
+interface DecisionModalProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  selectedUserRow: ApplicationRow | null;
+  selectedApplication: Application;
+  accessToken: string;
+}
+
+export const DecisionModal = ({
+  open,
+  setOpen,
+  selectedUserRow,
+  selectedApplication,
+  accessToken,
+}: DecisionModalProps) => {
+  const [decision, setDecision] = useState<Decision | ''>('');
+
+  const handleDecisionChange = (decision: Decision) => {
+    setDecision(decision);
+  };
+
+  const handleCloseDecisionModal = () => {
+    setOpen(false); // Close modal
+    setDecision(''); // Reset form
+  };
+
+  // Submit logic
+  const handleDecisionSubmit = async () => {
+    if (!selectedUserRow?.userId || !decision) {
+      alert('Please select a user and provide a decision on their application');
+      return;
+    }
+
+    try {
+      await apiClient.submitDecision(accessToken, selectedUserRow.userId, {
+        decision: decision,
+      });
+      alert('Decision submitted successfully!');
+      handleCloseDecisionModal();
+    } catch (error) {
+      console.error('Error submitting decision:', error);
+      alert('Failed to submit decision.');
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={handleCloseDecisionModal}>
+      <DialogTitle>Write Review</DialogTitle>
+      <DialogContent>
+        <div>
+          <Stack direction="row" alignItems="center" spacing={2} mb={2}>
+            <Typography variant="body1">Decision:</Typography>
+            <Select
+              name={`decision`}
+              value={decision || ''}
+              onChange={(e) => handleDecisionChange(e.target.value as Decision)}
+            >
+              <MenuItem value={Decision.ACCEPT}>Accept</MenuItem>
+              <MenuItem value={Decision.REJECT}>Reject</MenuItem>
+            </Select>
+          </Stack>
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCloseDecisionModal}>Cancel</Button>
+        <Button onClick={handleDecisionSubmit}>Submit Decision</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/apps/frontend/src/components/ApplicationTables/index.tsx
+++ b/apps/frontend/src/components/ApplicationTables/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { DataGrid, GridRowSelectionModel } from '@mui/x-data-grid';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import {
   Container,
   Typography,
@@ -100,15 +101,43 @@ export function ApplicationTable() {
 
   return (
     <Container maxWidth="xl">
-      <Typography variant="h4" mb={1}>
-        Welcome back, {fullName ? fullName : 'User'}
-      </Typography>
-      <Typography variant="h6" mb={1}>
-        Current Recruitment Cycle: {getCurrentSemester()} {getCurrentYear()}
-      </Typography>
-      <Typography variant="body1" mb={3}>
-        Assigned For Review: Jane Smith, John Doe (Complete by 5/1/2024)
-      </Typography>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          flexDirection: 'row',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            flexDirection: 'column',
+          }}
+        >
+          <Typography variant="h4" mb={1}>
+            Welcome back, {fullName ? fullName : 'User'}
+          </Typography>
+          <Typography variant="h6" mb={1}>
+            Current Recruitment Cycle: {getCurrentSemester()} {getCurrentYear()}
+          </Typography>
+          <Typography variant="body1" mb={3}>
+            Assigned For Review: Jane Smith, John Doe (Complete by 5/1/2024)
+          </Typography>
+        </div>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          sx={{ alignSelf: 'center' }}
+          onClick={() => {
+            fetchData();
+          }}
+          startIcon={<RefreshIcon />}
+        >
+          Refresh
+        </Button>
+      </div>
       <DataGrid
         rows={data}
         columns={applicationColumns}

--- a/apps/frontend/src/components/ApplicationTables/index.tsx
+++ b/apps/frontend/src/components/ApplicationTables/index.tsx
@@ -15,6 +15,7 @@ import { DoneOutline } from '@mui/icons-material';
 import { ApplicationRow, Application, Semester } from '../types';
 import apiClient from '@api/apiClient';
 import { applicationColumns } from './columns';
+import { DecisionModal } from './decisionModal';
 import { ReviewModal } from './reviewModal';
 import useLoginContext from '@components/LoginPage/useLoginContext';
 
@@ -47,9 +48,14 @@ export function ApplicationTable() {
     useState<Application | null>(null);
 
   const [openReviewModal, setOpenReviewModal] = useState(false);
+  const [openDecisionModal, setOpenDecisionModal] = useState(false);
 
   const handleOpenReviewModal = () => {
     setOpenReviewModal(true);
+  };
+
+  const handleOpenDecisionModal = () => {
+    setOpenDecisionModal(true);
   };
 
   const fetchData = async () => {
@@ -72,24 +78,6 @@ export function ApplicationTable() {
       alert('Failed to fetch application details.');
     }
   };
-
-  // const changeStage = async (
-  //   event: React.MouseEvent<HTMLButtonElement>,
-  //   userId: number,
-  // ) => {
-  //   console.log(`Attempting to change stage for userId: ${userId}`);
-  //   try {
-  //     const updatedApplication = await apiClient.changeStage(
-  //       accessToken,
-  //       userId,
-  //     );
-  //     console.log('Stage changed successfully:', updatedApplication.stage);
-  //     alert(`Stage updated to: ${updatedApplication.stage}`);
-  //   } catch (error) {
-  //     console.error('Error changing application stage:', error);
-  //     alert('Failed to change application stage.');
-  //   }
-  // };
 
   const getFullName = async () => {
     setFullName(await apiClient.getFullName(accessToken));
@@ -215,9 +203,7 @@ export function ApplicationTable() {
             </Button>
 
             {selectedUserRow && (
-              <Button
-              // onClick={(event) => changeStage(event, selectedUserRow.userId)}
-              >
+              <Button size="small" onClick={handleOpenDecisionModal}>
                 Move Stage
               </Button>
             )}
@@ -225,6 +211,13 @@ export function ApplicationTable() {
           <ReviewModal
             open={openReviewModal}
             setOpen={setOpenReviewModal}
+            selectedUserRow={selectedUserRow}
+            selectedApplication={selectedApplication}
+            accessToken={accessToken}
+          />
+          <DecisionModal
+            open={openDecisionModal}
+            setOpen={setOpenDecisionModal}
             selectedUserRow={selectedUserRow}
             selectedApplication={selectedApplication}
             accessToken={accessToken}

--- a/apps/frontend/src/components/types.ts
+++ b/apps/frontend/src/components/types.ts
@@ -70,6 +70,11 @@ type User = {
   status: string;
 };
 
+enum Decision {
+  ACCEPT = 'ACCEPT',
+  REJECT = 'REJECT',
+}
+
 export {
   User,
   ApplicationRow,
@@ -80,4 +85,5 @@ export {
   Response,
   Review,
   Semester,
+  Decision,
 };


### PR DESCRIPTION
### ℹ️ Issue

Closes 79

### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

Added a button for refreshing the application data on admin view, basically just re-fetches the data and has it updated accordingly. Also added functionality for the "move stage" button that shows when you click on a specific application, rejects and accepts (and moves stages of) applications

Briefly list the changes made to the code:
1. Created a decisionModal that matches the reviewModal, shows up when "Move Stage" button is pressed.
2. Created apiClient functionality for submitting a decision to the backend, that matches the endpoint in applications.controller.ts
3. IMPORTANT: commented out the @Column decorator of the reviews section of the applications configuration, I believe this is a bug. Not sure if you are allowed to have both @Column and @OneToMany
4. created a Decision enum to match the backend's 

### ✔️ Verification

I had sample applications, then rejected/accepted them, after clicking refresh button, their new states would be properly shown. 

Provide screenshots of any new components, styling changes, or pages. 
<img width="154" alt="Screenshot 2025-06-14 at 2 49 10 AM" src="https://github.com/user-attachments/assets/4cb2e865-c6e4-405a-a893-c7529ca6d58e" />
<img width="1182" alt="Screenshot 2025-06-14 at 2 49 58 AM" src="https://github.com/user-attachments/assets/2c94dea2-7474-4758-b153-01f4f9370710" />

### 🏕️ (Optional) Future Work / Notes

Changed the backend by commenting out the @Column decorator, when not removed, the apiClient keeps running 500 internal server errors. 
