### PR TITLE
119 create nav bar

### DIFF
--- a/apps/frontend/src/app.tsx
+++ b/apps/frontend/src/app.tsx
@@ -4,9 +4,15 @@ import { useState } from 'react';
 import Root from '@containers/root';
 import NotFound from '@containers/404';
 import Test from '@containers/test';
+import Dashboard from '@containers/dashboard';
+import Applications from '@containers/applications';
+import Resources from '@containers/resources';
+import Settings from '@containers/settings';
 import LoginContext from '@components/LoginPage/LoginContext';
 import ProtectedRoutes from '@components/ProtectedRoutes';
 import LoginPage from '@components/LoginPage';
+import Navigation from '@components/Navigation';
+import AdminRoutes from '@components/AdminRoutes';
 
 export const App: React.FC = () => {
   const [token, setToken] = useState<string>('');
@@ -16,13 +22,46 @@ export const App: React.FC = () => {
         <Routes>
           <Route path="/login" element={<LoginPage />} />
 
-          {/* Protected Routes */}
           <Route element={<ProtectedRoutes token={token} />}>
-            <Route path="/" element={<Root />} />
+            <Route element={<AdminRoutes />}>
+              <Route
+                path="/"
+                element={
+                  <Navigation>
+                    <Dashboard />
+                  </Navigation>
+                }
+              />
+              <Route
+                path="/applications"
+                element={
+                  <Navigation>
+                    <Applications />
+                  </Navigation>
+                }
+              />
+              <Route
+                path="/resources"
+                element={
+                  <Navigation>
+                    <Resources />
+                  </Navigation>
+                }
+              />
+              <Route
+                path="/settings"
+                element={
+                  <Navigation>
+                    <Settings />
+                  </Navigation>
+                }
+              />
+            </Route>
+
+            <Route path="/applicant" element={<Root />} />
             <Route path="/test" element={<Test />} />
           </Route>
 
-          {/* 404 Route */}
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/apps/frontend/src/components/AdminRoutes/index.tsx
+++ b/apps/frontend/src/components/AdminRoutes/index.tsx
@@ -16,7 +16,7 @@ const AdminRoutes: React.FC = () => {
       try {
         const userData = await apiClient.getUser(accessToken);
         setUser(userData);
-        
+
         if (userData?.status === 'Applicant') {
           navigate('/applicant');
         }
@@ -34,10 +34,10 @@ const AdminRoutes: React.FC = () => {
 
   if (loading) {
     return (
-      <Box 
-        display="flex" 
-        justifyContent="center" 
-        alignItems="center" 
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
         minHeight="100vh"
       >
         <CircularProgress />
@@ -53,4 +53,4 @@ const AdminRoutes: React.FC = () => {
   return null;
 };
 
-export default AdminRoutes; 
+export default AdminRoutes;

--- a/apps/frontend/src/components/AdminRoutes/index.tsx
+++ b/apps/frontend/src/components/AdminRoutes/index.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+import useLoginContext from '@components/LoginPage/useLoginContext';
+import apiClient from '@api/apiClient';
+import { User } from '@components/types';
+import { Box, CircularProgress } from '@mui/material';
+
+const AdminRoutes: React.FC = () => {
+  const { token: accessToken } = useLoginContext();
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const getUser = async () => {
+      try {
+        const userData = await apiClient.getUser(accessToken);
+        setUser(userData);
+        
+        if (userData?.status === 'Applicant') {
+          navigate('/applicant');
+        }
+      } catch (error) {
+        console.error('Error fetching user data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (accessToken) {
+      getUser();
+    }
+  }, [accessToken, navigate]);
+
+  if (loading) {
+    return (
+      <Box 
+        display="flex" 
+        justifyContent="center" 
+        alignItems="center" 
+        minHeight="100vh"
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (user?.status === 'Admin' || user?.status === 'Recruiter') {
+    return <Outlet />;
+  }
+
+  // this will be handled by the redirect in useeffect
+  return null;
+};
+
+export default AdminRoutes; 

--- a/apps/frontend/src/components/Navigation/index.tsx
+++ b/apps/frontend/src/components/Navigation/index.tsx
@@ -92,32 +92,39 @@ export const Navigation: React.FC<NavigationProps> = ({ children }) => {
   const drawerContent = (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       {!isMobile && (
-        <Toolbar sx={{ justifyContent: 'flex-end', minHeight: '64px !important' }}>
+        <Toolbar
+          sx={{ justifyContent: 'flex-end', minHeight: '64px !important' }}
+        >
           <IconButton onClick={handleCollapseToggle} size="small">
             {collapsed ? <MenuIcon /> : <ChevronLeftIcon />}
           </IconButton>
         </Toolbar>
       )}
-      
+
       <List sx={{ flexGrow: 1, pt: isMobile ? 2 : 0 }}>
         {navigationItems.map((item) => {
           const isActive = isActivePath(item.path);
-          
+
           return (
             <ListItem key={item.text} disablePadding>
-              <Tooltip 
-                title={item.text} 
-                placement="right" 
+              <Tooltip
+                title={item.text}
+                placement="right"
                 disableHoverListener={!collapsed || isMobile}
               >
                 <ListItemButton
                   onClick={() => handleNavigation(item.path)}
                   sx={{
                     minHeight: 48,
-                    justifyContent: collapsed && !isMobile ? 'center' : 'initial',
+                    justifyContent:
+                      collapsed && !isMobile ? 'center' : 'initial',
                     px: 2.5,
-                    backgroundColor: isActive ? theme.palette.action.selected : 'transparent',
-                    borderRight: isActive ? `3px solid ${theme.palette.primary.main}` : 'none',
+                    backgroundColor: isActive
+                      ? theme.palette.action.selected
+                      : 'transparent',
+                    borderRight: isActive
+                      ? `3px solid ${theme.palette.primary.main}`
+                      : 'none',
                     '&:hover': {
                       backgroundColor: theme.palette.action.hover,
                     },
@@ -128,16 +135,20 @@ export const Navigation: React.FC<NavigationProps> = ({ children }) => {
                       minWidth: 0,
                       mr: collapsed && !isMobile ? 'auto' : 3,
                       justifyContent: 'center',
-                      color: isActive ? theme.palette.primary.main : theme.palette.text.secondary,
+                      color: isActive
+                        ? theme.palette.primary.main
+                        : theme.palette.text.secondary,
                     }}
                   >
                     {item.icon}
                   </ListItemIcon>
                   {(!collapsed || isMobile) && (
-                    <ListItemText 
+                    <ListItemText
                       primary={item.text}
                       sx={{
-                        color: isActive ? theme.palette.primary.main : theme.palette.text.primary,
+                        color: isActive
+                          ? theme.palette.primary.main
+                          : theme.palette.text.primary,
                         fontWeight: isActive ? 600 : 400,
                       }}
                     />
@@ -185,21 +196,21 @@ export const Navigation: React.FC<NavigationProps> = ({ children }) => {
         open={isMobile ? mobileOpen : true}
         onClose={handleDrawerToggle}
         ModalProps={{
-          keepMounted: true, 
+          keepMounted: true,
         }}
         sx={{
-          width: isMobile 
-            ? DRAWER_WIDTH 
-            : collapsed 
-              ? COLLAPSED_DRAWER_WIDTH 
-              : DRAWER_WIDTH,
+          width: isMobile
+            ? DRAWER_WIDTH
+            : collapsed
+            ? COLLAPSED_DRAWER_WIDTH
+            : DRAWER_WIDTH,
           flexShrink: 0,
           '& .MuiDrawer-paper': {
-            width: isMobile 
-              ? DRAWER_WIDTH 
-              : collapsed 
-                ? COLLAPSED_DRAWER_WIDTH 
-                : DRAWER_WIDTH,
+            width: isMobile
+              ? DRAWER_WIDTH
+              : collapsed
+              ? COLLAPSED_DRAWER_WIDTH
+              : DRAWER_WIDTH,
             boxSizing: 'border-box',
             borderRight: `1px solid ${theme.palette.divider}`,
             backgroundColor: theme.palette.background.paper,
@@ -219,8 +230,8 @@ export const Navigation: React.FC<NavigationProps> = ({ children }) => {
           flexGrow: 1,
           width: {
             xs: '100%',
-            md: collapsed 
-              ? `calc(100% - ${COLLAPSED_DRAWER_WIDTH}px)` 
+            md: collapsed
+              ? `calc(100% - ${COLLAPSED_DRAWER_WIDTH}px)`
               : `calc(100% - ${DRAWER_WIDTH}px)`,
           },
           marginTop: isMobile ? '64px' : 0,
@@ -236,4 +247,4 @@ export const Navigation: React.FC<NavigationProps> = ({ children }) => {
   );
 };
 
-export default Navigation; 
+export default Navigation;

--- a/apps/frontend/src/components/Navigation/index.tsx
+++ b/apps/frontend/src/components/Navigation/index.tsx
@@ -1,0 +1,239 @@
+import React, { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+  useMediaQuery,
+  useTheme,
+  IconButton,
+  Box,
+  Toolbar,
+} from '@mui/material';
+import {
+  Dashboard as DashboardIcon,
+  Chat as ApplicationsIcon,
+  Book as ResourcesIcon,
+  Settings as SettingsIcon,
+  Menu as MenuIcon,
+  ChevronLeft as ChevronLeftIcon,
+} from '@mui/icons-material';
+
+interface NavigationItem {
+  text: string;
+  path: string;
+  icon: React.ReactElement;
+}
+
+const navigationItems: NavigationItem[] = [
+  {
+    text: 'Dashboard',
+    path: '/',
+    icon: <DashboardIcon />,
+  },
+  {
+    text: 'Applications',
+    path: '/applications',
+    icon: <ApplicationsIcon />,
+  },
+  {
+    text: 'Resources',
+    path: '/resources',
+    icon: <ResourcesIcon />,
+  },
+  {
+    text: 'Settings',
+    path: '/settings',
+    icon: <SettingsIcon />,
+  },
+];
+
+const DRAWER_WIDTH = 240;
+const COLLAPSED_DRAWER_WIDTH = 64;
+
+interface NavigationProps {
+  children: React.ReactNode;
+}
+
+export const Navigation: React.FC<NavigationProps> = ({ children }) => {
+  const theme = useTheme();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  const handleCollapseToggle = () => {
+    setCollapsed(!collapsed);
+  };
+
+  const handleNavigation = (path: string) => {
+    navigate(path);
+    if (isMobile) {
+      setMobileOpen(false);
+    }
+  };
+
+  const isActivePath = (path: string) => {
+    if (path === '/') {
+      return location.pathname === '/';
+    }
+    return location.pathname.startsWith(path);
+  };
+
+  const drawerContent = (
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      {!isMobile && (
+        <Toolbar sx={{ justifyContent: 'flex-end', minHeight: '64px !important' }}>
+          <IconButton onClick={handleCollapseToggle} size="small">
+            {collapsed ? <MenuIcon /> : <ChevronLeftIcon />}
+          </IconButton>
+        </Toolbar>
+      )}
+      
+      <List sx={{ flexGrow: 1, pt: isMobile ? 2 : 0 }}>
+        {navigationItems.map((item) => {
+          const isActive = isActivePath(item.path);
+          
+          return (
+            <ListItem key={item.text} disablePadding>
+              <Tooltip 
+                title={item.text} 
+                placement="right" 
+                disableHoverListener={!collapsed || isMobile}
+              >
+                <ListItemButton
+                  onClick={() => handleNavigation(item.path)}
+                  sx={{
+                    minHeight: 48,
+                    justifyContent: collapsed && !isMobile ? 'center' : 'initial',
+                    px: 2.5,
+                    backgroundColor: isActive ? theme.palette.action.selected : 'transparent',
+                    borderRight: isActive ? `3px solid ${theme.palette.primary.main}` : 'none',
+                    '&:hover': {
+                      backgroundColor: theme.palette.action.hover,
+                    },
+                  }}
+                >
+                  <ListItemIcon
+                    sx={{
+                      minWidth: 0,
+                      mr: collapsed && !isMobile ? 'auto' : 3,
+                      justifyContent: 'center',
+                      color: isActive ? theme.palette.primary.main : theme.palette.text.secondary,
+                    }}
+                  >
+                    {item.icon}
+                  </ListItemIcon>
+                  {(!collapsed || isMobile) && (
+                    <ListItemText 
+                      primary={item.text}
+                      sx={{
+                        color: isActive ? theme.palette.primary.main : theme.palette.text.primary,
+                        fontWeight: isActive ? 600 : 400,
+                      }}
+                    />
+                  )}
+                </ListItemButton>
+              </Tooltip>
+            </ListItem>
+          );
+        })}
+      </List>
+    </Box>
+  );
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      {isMobile && (
+        <Box
+          sx={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            zIndex: theme.zIndex.appBar,
+            backgroundColor: theme.palette.background.paper,
+            borderBottom: `1px solid ${theme.palette.divider}`,
+            height: 64,
+            display: 'flex',
+            alignItems: 'center',
+            px: 2,
+          }}
+        >
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={handleDrawerToggle}
+          >
+            <MenuIcon />
+          </IconButton>
+        </Box>
+      )}
+
+      <Drawer
+        variant={isMobile ? 'temporary' : 'permanent'}
+        open={isMobile ? mobileOpen : true}
+        onClose={handleDrawerToggle}
+        ModalProps={{
+          keepMounted: true, 
+        }}
+        sx={{
+          width: isMobile 
+            ? DRAWER_WIDTH 
+            : collapsed 
+              ? COLLAPSED_DRAWER_WIDTH 
+              : DRAWER_WIDTH,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: isMobile 
+              ? DRAWER_WIDTH 
+              : collapsed 
+                ? COLLAPSED_DRAWER_WIDTH 
+                : DRAWER_WIDTH,
+            boxSizing: 'border-box',
+            borderRight: `1px solid ${theme.palette.divider}`,
+            backgroundColor: theme.palette.background.paper,
+            transition: theme.transitions.create('width', {
+              easing: theme.transitions.easing.sharp,
+              duration: theme.transitions.duration.enteringScreen,
+            }),
+          },
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          width: {
+            xs: '100%',
+            md: collapsed 
+              ? `calc(100% - ${COLLAPSED_DRAWER_WIDTH}px)` 
+              : `calc(100% - ${DRAWER_WIDTH}px)`,
+          },
+          marginTop: isMobile ? '64px' : 0,
+          transition: theme.transitions.create('width', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.enteringScreen,
+          }),
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+};
+
+export default Navigation; 

--- a/apps/frontend/src/containers/applications.tsx
+++ b/apps/frontend/src/containers/applications.tsx
@@ -5,4 +5,4 @@ const Applications: React.FC = () => {
   return <ApplicationTable />;
 };
 
-export default Applications; 
+export default Applications;

--- a/apps/frontend/src/containers/applications.tsx
+++ b/apps/frontend/src/containers/applications.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ApplicationTable } from '@components/ApplicationTables';
+
+const Applications: React.FC = () => {
+  return <ApplicationTable />;
+};
+
+export default Applications; 

--- a/apps/frontend/src/containers/dashboard.tsx
+++ b/apps/frontend/src/containers/dashboard.tsx
@@ -13,4 +13,4 @@ const Dashboard: React.FC = () => {
   );
 };
 
-export default Dashboard; 
+export default Dashboard;

--- a/apps/frontend/src/containers/dashboard.tsx
+++ b/apps/frontend/src/containers/dashboard.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Container, Typography, Box } from '@mui/material';
+
+const Dashboard: React.FC = () => {
+  return (
+    <Container maxWidth="xl" sx={{ py: 3 }}>
+      <Box>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Dashboard
+        </Typography>
+      </Box>
+    </Container>
+  );
+};
+
+export default Dashboard; 

--- a/apps/frontend/src/containers/resources.tsx
+++ b/apps/frontend/src/containers/resources.tsx
@@ -13,4 +13,4 @@ const Resources: React.FC = () => {
   );
 };
 
-export default Resources; 
+export default Resources;

--- a/apps/frontend/src/containers/resources.tsx
+++ b/apps/frontend/src/containers/resources.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Container, Typography, Box } from '@mui/material';
+
+const Resources: React.FC = () => {
+  return (
+    <Container maxWidth="xl" sx={{ py: 3 }}>
+      <Box>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Resources
+        </Typography>
+      </Box>
+    </Container>
+  );
+};
+
+export default Resources; 

--- a/apps/frontend/src/containers/root.tsx
+++ b/apps/frontend/src/containers/root.tsx
@@ -1,9 +1,9 @@
-import { ApplicationTable } from '@components/ApplicationTables';
 import { ApplicantView } from '@components/ApplicantView/user';
 import useLoginContext from '@components/LoginPage/useLoginContext';
 import apiClient from '@api/apiClient';
 import { useEffect, useState } from 'react';
 import { User } from '@components/types';
+
 const Root: React.FC = () => {
   const { token: accessToken } = useLoginContext();
   const [user, setUser] = useState<User>();
@@ -14,12 +14,12 @@ const Root: React.FC = () => {
     };
     getUser();
   }, [accessToken]);
-  // (user?.status === 'Admin' || user?.status === 'Recruiter')
+  // only applicants can see this now.
   if (user?.status === 'Applicant') {
     return <ApplicantView user={user} />;
-  } else {
-    return <ApplicationTable />;
   }
+
+  return null;
 };
 
 export default Root;

--- a/apps/frontend/src/containers/settings.tsx
+++ b/apps/frontend/src/containers/settings.tsx
@@ -13,4 +13,4 @@ const Settings: React.FC = () => {
   );
 };
 
-export default Settings; 
+export default Settings;

--- a/apps/frontend/src/containers/settings.tsx
+++ b/apps/frontend/src/containers/settings.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Container, Typography, Box } from '@mui/material';
+
+const Settings: React.FC = () => {
+  return (
+    <Container maxWidth="xl" sx={{ py: 3 }}>
+      <Box>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Settings
+        </Typography>
+      </Box>
+    </Container>
+  );
+};
+
+export default Settings; 


### PR DESCRIPTION
### ℹ️ Issue

Closes #119 

* Added `AdminRoutes` component to restrict access to certain routes based on user roles (Admin or Recruiter). It fetches user data using the `apiClient` and redirects unauthorized users to the `/applicant` page. 

* Introduced a new `Navigation` component with a responsive, collapsible drawer for navigating between admin/recruiter pages (Dashboard, Applications, Resources, Settings). It highlights the active route and adapts to mobile screens. 
* Integrated the `Navigation` component into the `AdminRoutes` layout for consistent navigation across admin/recruiter pages. 

* Created new placeholder components and pages

### ✔️ Verification
* Logged in as both applicant and admin/recruiter to confirm intended behaviors.

Provide screenshots of any new components, styling changes, or pages. 
![image](https://github.com/user-attachments/assets/0e5fd7f5-48cb-444b-955b-98539f8a2cb1)
![image](https://github.com/user-attachments/assets/477ef6b8-db08-4198-b631-318e424af7bf)
![image](https://github.com/user-attachments/assets/930b9637-75c3-4ed0-9768-36f9564a6d67)


### 🏕️ (Optional) Future Work / Notes