### PR TITLE
update stages & review categories

### DIFF
--- a/apps/backend/src/applications/application.entity.ts
+++ b/apps/backend/src/applications/application.entity.ts
@@ -14,6 +14,7 @@ import {
   Position,
   ApplicationStage,
   ApplicationStep,
+  ReviewStatus,
 } from './types';
 import { GetApplicationResponseDTO } from './dto/get-application.response.dto';
 import { Review } from '../reviews/review.entity';
@@ -54,9 +55,16 @@ export class Application {
   @IsEnum(Position)
   position: Position;
 
-  @Column('varchar', { default: ApplicationStage.RESUME, nullable: false })
+  @Column('varchar', {
+    default: ApplicationStage.APP_RECEIVED,
+    nullable: false,
+  })
   @IsEnum(ApplicationStage)
   stage: ApplicationStage;
+
+  @Column('varchar', { default: ReviewStatus.UNASSIGNED, nullable: false })
+  @IsEnum(ReviewStatus)
+  review: ReviewStatus;
 
   @Column('varchar', { default: ApplicationStep.SUBMITTED, nullable: false })
   step: ApplicationStep;
@@ -87,6 +95,7 @@ export class Application {
       stage: this.stage,
       step: applicationStep,
       position: this.position,
+      review: this.review,
       createdAt: this.createdAt,
       meanRatingAllReviews,
       meanRatingResume,
@@ -108,6 +117,7 @@ export class Application {
       position: this.position,
       stage: this.stage,
       step: applicationStep,
+      review: this.review,
       response: this.response,
       reviews: this.reviews,
       numApps,

--- a/apps/backend/src/applications/applications.constants.ts
+++ b/apps/backend/src/applications/applications.constants.ts
@@ -1,27 +1,27 @@
 import { ApplicationStage, Position } from './types';
 
-const DEV_STAGES = [
-  ApplicationStage.RESUME,
-  ApplicationStage.TECHNICAL_CHALLENGE,
-  ApplicationStage.INTERVIEW,
-  ApplicationStage.ACCEPTED,
-];
+// const DEV_STAGES = [
+//   ApplicationStage.RESUME,
+//   ApplicationStage.TECHNICAL_CHALLENGE,
+//   ApplicationStage.INTERVIEW,
+//   ApplicationStage.ACCEPTED,
+// ];
 
-const PM_STAGES = [
-  ApplicationStage.RESUME,
-  ApplicationStage.PM_CHALLENGE,
-  ApplicationStage.INTERVIEW,
-  ApplicationStage.ACCEPTED,
-];
+// const PM_STAGES = [
+//   ApplicationStage.RESUME,
+//   ApplicationStage.PM_CHALLENGE,
+//   ApplicationStage.INTERVIEW,
+//   ApplicationStage.ACCEPTED,
+// ];
 
-const DESIGNER_STAGES = [
-  ApplicationStage.RESUME,
-  ApplicationStage.INTERVIEW,
-  ApplicationStage.ACCEPTED,
-];
+// const DESIGNER_STAGES = [
+//   ApplicationStage.RESUME,
+//   ApplicationStage.INTERVIEW,
+//   ApplicationStage.ACCEPTED,
+// ];
 
-export const stagesMap: Record<Position, ApplicationStage[]> = {
-  [Position.DEVELOPER]: DEV_STAGES,
-  [Position.PM]: PM_STAGES,
-  [Position.DESIGNER]: DESIGNER_STAGES,
-};
+// export const stagesMap: Record<Position, ApplicationStage[]> = {
+//   [Position.DEVELOPER]: DEV_STAGES,
+//   [Position.PM]: PM_STAGES,
+//   [Position.DESIGNER]: DESIGNER_STAGES,
+// };

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -18,7 +18,7 @@ import * as crypto from 'crypto';
 import { User } from '../users/user.entity';
 import { Position, ApplicationStage, ApplicationStep } from './types';
 import { GetAllApplicationResponseDTO } from './dto/get-all-application.response.dto';
-import { stagesMap } from './applications.constants';
+//import { stagesMap } from './applications.constants';
 
 @Injectable()
 export class ApplicationsService {
@@ -54,7 +54,7 @@ export class ApplicationsService {
       year,
       semester,
       position: Position.DEVELOPER, // TODO: Change this to be dynamic
-      stage: ApplicationStage.RESUME,
+      stage: ApplicationStage.APP_RECEIVED,
       step: ApplicationStep.SUBMITTED,
       response: application,
       reviews: [],
@@ -112,14 +112,15 @@ export class ApplicationsService {
     let newStage: ApplicationStage;
     if (decision === Decision.REJECT) {
       newStage = ApplicationStage.REJECTED;
-    } else {
-      const stagesArr = stagesMap[application.position];
-      const stageIndex = stagesArr.indexOf(application.stage);
-      if (stageIndex === -1) {
-        return;
-      }
-      newStage = stagesArr[stageIndex + 1];
     }
+    // else {
+    // const stagesArr = stagesMap[application.position];
+    // const stageIndex = stagesArr.indexOf(application.stage);
+    // if (stageIndex === -1) {
+    //   return;
+    // }
+    // newStage = stagesArr[stageIndex + 1];
+    // }
     application.stage = newStage;
 
     //Save the updated stage
@@ -161,18 +162,18 @@ export class ApplicationsService {
 
       // Filter reviews by stage and calculate mean ratings accordingly
       const resumeReviews = app.reviews.filter(
-        (review) => review.stage === ApplicationStage.RESUME,
+        (review) => review.stage === ApplicationStage.APP_RECEIVED,
       );
       const challengeReviews = app.reviews.filter(
         (review) =>
-          review.stage === ApplicationStage.TECHNICAL_CHALLENGE ||
+          review.stage === ApplicationStage.T_INTERVIEW ||
           review.stage === ApplicationStage.PM_CHALLENGE,
       );
       const technicalChallengeReviews = app.reviews.filter(
-        (review) => review.stage === ApplicationStage.TECHNICAL_CHALLENGE,
+        (review) => review.stage === ApplicationStage.T_INTERVIEW,
       );
       const interviewReviews = app.reviews.filter(
-        (review) => review.stage === ApplicationStage.INTERVIEW,
+        (review) => review.stage === ApplicationStage.B_INTERVIEW,
       );
 
       // Mean rating for RESUME stage

--- a/apps/backend/src/applications/dto/application-status.ts
+++ b/apps/backend/src/applications/dto/application-status.ts
@@ -1,10 +1,14 @@
-import { stagesMap } from '../applications.constants';
-import { ApplicationStage, ApplicationStep, Position } from '../types';
+//import { stagesMap } from '../applications.constants';
+import {
+  ApplicationStage,
+  ApplicationStep,
+  ApplicationStageOrder,
+} from '../types';
 
 export class ApplicationStatus {
   constructor(private stage: ApplicationStage, private step: ApplicationStep) {}
 
-  public getNextStatus(position: Position): ApplicationStatus | null {
+  public getNextStatus(): ApplicationStatus | null {
     if (
       [ApplicationStage.ACCEPTED, ApplicationStage.REJECTED].includes(
         this.stage,
@@ -17,11 +21,21 @@ export class ApplicationStatus {
       this.step === ApplicationStep.SUBMITTED
         ? ApplicationStep.REVIEWED
         : ApplicationStep.SUBMITTED;
-    const nextStage =
-      this.step === ApplicationStep.SUBMITTED
-        ? this.stage
-        : stagesMap[position][stagesMap[position].indexOf(this.stage) + 1];
+    const nextStage = this.getNextApplicationStage(this.stage);
 
     return new ApplicationStatus(nextStage, nextStep);
+  }
+
+  public getNextApplicationStage(
+    current: ApplicationStage,
+  ): ApplicationStage | undefined {
+    const currentIndex = ApplicationStageOrder.indexOf(current);
+    if (
+      currentIndex !== -1 &&
+      currentIndex < ApplicationStageOrder.length - 1
+    ) {
+      return ApplicationStageOrder[currentIndex + 1];
+    }
+    return undefined;
   }
 }

--- a/apps/backend/src/applications/dto/get-all-application.response.dto.ts
+++ b/apps/backend/src/applications/dto/get-all-application.response.dto.ts
@@ -1,5 +1,10 @@
 import { IsDate, IsEnum, IsPositive, IsString } from 'class-validator';
-import { ApplicationStage, ApplicationStep, Position } from '../types';
+import {
+  ApplicationStage,
+  ApplicationStep,
+  Position,
+  ReviewStatus,
+} from '../types';
 
 export class GetAllApplicationResponseDTO {
   @IsPositive()
@@ -16,6 +21,9 @@ export class GetAllApplicationResponseDTO {
 
   @IsEnum(ApplicationStep)
   step: ApplicationStep;
+
+  @IsEnum(ReviewStatus)
+  review: ReviewStatus;
 
   @IsEnum(Position)
   position: Position;

--- a/apps/backend/src/applications/dto/get-application.response.dto.ts
+++ b/apps/backend/src/applications/dto/get-application.response.dto.ts
@@ -4,6 +4,7 @@ import {
   ApplicationStep,
   Position,
   Response,
+  ReviewStatus,
   Semester,
 } from '../types';
 
@@ -21,6 +22,8 @@ export class GetApplicationResponseDTO {
   stage: ApplicationStage;
 
   step: ApplicationStep;
+
+  review: ReviewStatus;
 
   response: Response[];
 

--- a/apps/backend/src/applications/types.ts
+++ b/apps/backend/src/applications/types.ts
@@ -8,20 +8,33 @@ export enum Semester {
   SPRING = 'SPRING',
 }
 
-export enum ApplicationStage {
-  RESUME = 'RESUME',
-  INTERVIEW = 'INTERVIEW',
-  ACCEPTED = 'ACCEPTED',
-  REJECTED = 'REJECTED',
-
-  // Devs only
-  TECHNICAL_CHALLENGE = 'TECHNICAL_CHALLENGE',
-  // PMs only
-  PM_CHALLENGE = 'PM_CHALLENGE',
-}
-
 export enum ApplicationStep {
   SUBMITTED = 'SUBMITTED',
+  REVIEWED = 'REVIEWED',
+}
+
+export enum ApplicationStage {
+  APP_RECEIVED = 'Application Received',
+  PM_CHALLENGE = 'PM Challenge',
+  B_INTERVIEW = 'Behavioral Interview',
+  T_INTERVIEW = 'Technical Interview',
+  ACCEPTED = 'ACCEPTED',
+  REJECTED = 'REJECTED',
+}
+
+export const ApplicationStageOrder: ApplicationStage[] = [
+  ApplicationStage.APP_RECEIVED,
+  ApplicationStage.PM_CHALLENGE,
+  ApplicationStage.B_INTERVIEW,
+  ApplicationStage.T_INTERVIEW,
+  ApplicationStage.ACCEPTED,
+  ApplicationStage.REJECTED,
+];
+
+export enum ReviewStatus {
+  UNASSIGNED = 'UNASSIGNED',
+  ASSIGNED = 'ASSIGNED',
+  REVIEWING = 'REVIEWING',
   REVIEWED = 'REVIEWED',
 }
 

--- a/apps/frontend/src/components/ApplicationTables/columns.ts
+++ b/apps/frontend/src/components/ApplicationTables/columns.ts
@@ -2,21 +2,26 @@ export const applicationColumns = [
   {
     field: 'firstName',
     headerName: 'First Name',
-    width: 150,
+    width: 125,
   },
   {
     field: 'lastName',
     headerName: 'Last Name',
-    width: 150,
+    width: 125,
   },
   {
     field: 'stage',
     headerName: 'Stage',
-    width: 125,
+    width: 150,
   },
   {
     field: 'step',
     headerName: 'Status',
+    width: 125,
+  },
+  {
+    field: 'review',
+    headerName: 'Review',
     width: 125,
   },
   {
@@ -27,7 +32,7 @@ export const applicationColumns = [
   {
     field: 'createdAt',
     headerName: 'Date',
-    width: 150,
+    width: 125,
   },
   {
     field: 'meanRatingAllStages',

--- a/apps/frontend/src/components/ApplicationTables/index.tsx
+++ b/apps/frontend/src/components/ApplicationTables/index.tsx
@@ -148,6 +148,9 @@ export function ApplicationTable() {
               Status: {selectedApplication.step}
             </Typography>
             <Typography variant="body1">
+              Review: {selectedApplication.review}
+            </Typography>
+            <Typography variant="body1">
               Applications: {selectedApplication.numApps}
             </Typography>
           </Stack>

--- a/apps/frontend/src/components/types.ts
+++ b/apps/frontend/src/components/types.ts
@@ -1,10 +1,17 @@
 enum ApplicationStage {
-  RESUME = 'RESUME',
-  INTERVIEW = 'INTERVIEW',
+  APP_RECEIVED = 'Application Received',
+  PM_CHALLENGE = 'PM Challenge',
+  B_INTERVIEW = 'Behavioral Interview',
+  T_INTERVIEW = 'Technical Interview',
   ACCEPTED = 'ACCEPTED',
   REJECTED = 'REJECTED',
-  TECHNICAL_CHALLENGE = 'TECHNICAL_CHALLENGE',
-  PM_CHALLENGE = 'PM_CHALLENGE',
+}
+
+enum ReviewStatus {
+  UNASSIGNED = 'UNASSIGNED',
+  ASSIGNED = 'ASSIGNED',
+  REVIEWING = 'REVIEWING',
+  REVIEWED = 'REVIEWED',
 }
 
 enum ApplicationStep {
@@ -25,6 +32,7 @@ type ApplicationRow = {
   lastName: string;
   stage: ApplicationStage;
   step: ApplicationStep;
+  review: ReviewStatus;
   position: Position;
   createdAt: string;
   meanRatingAllStages: number;
@@ -59,6 +67,7 @@ type Application = {
   position: Position;
   stage: ApplicationStage;
   step: ApplicationStep;
+  review: ReviewStatus;
   response: Response[];
   numApps: number;
   reviews: Review[];
@@ -69,6 +78,7 @@ export {
   Application,
   ApplicationStage,
   ApplicationStep,
+  ReviewStatus,
   Position,
   Response,
   Review,


### PR DESCRIPTION
### ℹ️ Issue

Closes #123

### 📝 Description

Edited the enums for Stage and added a Review field to streamline applicant assessments are requested. The 2 columns on the application table should reflect the new values apart of these fields. The stage map was refactored to an array of the stages as they were streamlined. The next stage of the user is now found using a helper function. Filtering was tested with various spellings to ensure the queried applications appear. For new applications, the stage field now defaults to "Application Submitted" and the review field defaults to "UNASSIGNED". The stage and review values also show up when opening the full application details.

### ✔️ Verification

<img width="1111" alt="Screenshot 2025-07-02 at 4 50 53 PM" src="https://github.com/user-attachments/assets/64f7d758-2ea6-4525-a63c-3f13a9fd3d11" />

<img width="559" alt="Screenshot 2025-07-02 at 4 52 08 PM" src="https://github.com/user-attachments/assets/1382d187-9912-4dcb-80b2-5aadd4930b30" />

<img width="292" alt="Screenshot 2025-07-02 at 4 52 27 PM" src="https://github.com/user-attachments/assets/a32eb78d-92c0-400c-8181-bb727d4a72ba" />

<img width="446" alt="Screenshot 2025-07-02 at 4 53 30 PM" src="https://github.com/user-attachments/assets/b7c959a6-33f9-44cb-9dc4-e2411e40c95c" />


### 🏕️ (Optional) Future Work / Notes

The types between the backend and frontend should be consolidated as I had to put copies of the same enum in 2 different files. I also commented out some of the application constants in the backend just in case C4C decides to revert to the previous implementation. 
