### PR TITLE
RM-150: Recruiter dashboard (table) view

### DIFF
--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -292,28 +292,30 @@ export class ApplicationsService {
   async findAllCurrentApplications(
     currentUser?: User,
   ): Promise<GetAllApplicationResponseDTO[]> {
-    // Base query for current cycle applications
-    interface ApplicationWhereClause {
-      year: number;
-      semester: Semester;
-      assignedRecruiterIds?: ReturnType<typeof In>;
+    const year = getCurrentYear();
+    const semester = getCurrentSemester();
+
+    let applications: Application[];
+
+    if (currentUser?.status === UserStatus.RECRUITER) {
+      const recruiterId = Number(currentUser.id);
+
+      applications = await this.applicationsRepository
+        .createQueryBuilder('application')
+        .leftJoinAndSelect('application.user', 'user')
+        .leftJoinAndSelect('application.reviews', 'reviews')
+        .where(':rid = ANY(application.assignedRecruiterIds)', {
+          rid: recruiterId,
+        })
+        .andWhere('application.year = :year', { year })
+        .andWhere('application.semester = :semester', { semester })
+        .getMany();
+    } else {
+      applications = await this.applicationsRepository.find({
+        where: { year, semester },
+        relations: ['user', 'reviews'],
+      });
     }
-
-    const baseWhere: ApplicationWhereClause = {
-      year: getCurrentYear(),
-      semester: getCurrentSemester(),
-    };
-
-    // If user is a recruiter, only show applications assigned to them by
-    // checking where assignedRecruiterIds includes the user's id
-    if (currentUser && currentUser.status === UserStatus.RECRUITER) {
-      baseWhere.assignedRecruiterIds = In([currentUser.id]);
-    }
-
-    const applications = await this.applicationsRepository.find({
-      where: baseWhere,
-      relations: ['user', 'reviews'],
-    });
 
     const allApplicationsDto = await Promise.all(
       applications.map(async (app) => {

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -59,7 +59,7 @@ export class ApiClient {
       name: app.firstName + ' ' + app.lastName,
       position: app.position,
       stage: app.stage,
-      step: app.step,
+      review: app.review,
       // If no reviews/ratings, set to null, else display
       rating:
         app.meanRatingAllReviews && app.meanRatingAllReviews > 0

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -59,6 +59,7 @@ export class ApiClient {
       name: app.firstName + ' ' + app.lastName,
       position: app.position,
       stage: app.stage,
+      step: app.step,
       // If no reviews/ratings, set to null, else display
       rating:
         app.meanRatingAllReviews && app.meanRatingAllReviews > 0

--- a/apps/frontend/src/components/ApplicationTables/columns.tsx
+++ b/apps/frontend/src/components/ApplicationTables/columns.tsx
@@ -80,7 +80,7 @@ export const applicationColumns = (
     headerAlign: 'left',
     type: 'singleSelect',
     valueOptions: [...REVIEWED_STATUSES],
-    sortable: false,
+    sortable: true,
     renderHeader: (): React.ReactNode => (
       <strong style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
         Reviewed <FilterList sx={{ fontSize: 16 }} />
@@ -88,8 +88,8 @@ export const applicationColumns = (
     ),
   },
   {
-    field: 'assignedTo', // must match your data
-    headerName: 'Assigned Recruiters',
+    field: 'assignedTo',
+    headerName: 'Assigned to:',
     flex: 1,
     sortable: false,
     disableColumnMenu: true,
@@ -116,7 +116,7 @@ export const applicationColumns = (
     headerAlign: 'left',
     type: 'singleSelect',
     valueOptions: [...STAGE_STATUSES], // ← spread to fix readonly type
-    sortable: false,
+    sortable: true,
     renderHeader: (): React.ReactNode => (
       <strong style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
         App Stage <FilterList sx={{ fontSize: 16 }} />
@@ -134,7 +134,7 @@ export const applicationColumns = (
     headerName: 'Rating',
     flex: 1,
     headerAlign: 'left',
-    sortable: false,
+    sortable: true,
     disableColumnMenu: true,
     renderHeader: (): React.ReactNode => <strong>Rating</strong>,
     renderCell: (

--- a/apps/frontend/src/components/RecruiterView/Table.tsx
+++ b/apps/frontend/src/components/RecruiterView/Table.tsx
@@ -1,0 +1,168 @@
+import apiClient from '@api/apiClient';
+import useLoginContext from '@components/LoginPage/useLoginContext';
+import { Application, ApplicationRow, Semester } from '@components/types';
+import { Container, Stack, Typography } from '@mui/material';
+import { DataGrid } from '@mui/x-data-grid';
+import { GridRowSelectionModel } from '@mui/x-data-grid/models/gridRowSelectionModel';
+import { useEffect, useRef, useState } from 'react';
+import { RecruiterColumns } from './columns';
+
+export function RecruiterTable() {
+  const TODAY = new Date();
+
+  const getCurrentSemester = (): Semester => {
+    const month: number = TODAY.getMonth();
+    if (month >= 1 && month <= 7) {
+      return Semester.FALL; // Feb - Aug
+    }
+    return Semester.SPRING; // Sep - Jan
+  };
+
+  const getCurrentYear = (): number => {
+    return TODAY.getFullYear();
+  };
+
+  const isPageRendered = useRef<boolean>(false);
+
+  const { token: accessToken } = useLoginContext();
+  const [data, setData] = useState<ApplicationRow[]>([]);
+  const [fullName, setFullName] = useState<string>('');
+  const [rowSelection, setRowSelection] = useState<GridRowSelectionModel>([]);
+  const [selectedUserRow, setSelectedUserRow] = useState<ApplicationRow | null>(
+    null,
+  );
+  const [selectedApplication, setSelectedApplication] =
+    useState<Application | null>(null);
+
+  const getApplication = async (userId: number) => {
+    try {
+      const application = await apiClient.getApplication(accessToken, userId);
+      setSelectedApplication(application);
+    } catch (error) {
+      console.error('Error fetching application:', error);
+      alert('Failed to fetch application details.');
+    }
+  };
+
+  const fetchData = async () => {
+    const data = await apiClient.getAllApplications(accessToken);
+    // Each application needs an id for the DataGrid to work
+    if (data) {
+      data.forEach((row, index) => {
+        row.id = index;
+      });
+      setData(data);
+    }
+  };
+
+  const getFullName = async () => {
+    setFullName(await apiClient.getFullName(accessToken));
+  };
+
+  useEffect(() => {
+    fetchData();
+    getFullName();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accessToken]);
+
+  useEffect(() => {
+    if (rowSelection.length > 0) {
+      setSelectedUserRow(data[rowSelection[0] as number]);
+    }
+  }, [rowSelection, data]);
+
+  useEffect(() => {
+    if (rowSelection.length > 0) {
+      setSelectedUserRow(data[rowSelection[0] as number]);
+    }
+  }, [rowSelection, data]);
+
+  return (
+    <Container maxWidth="xl">
+      <Stack direction="row" alignItems="center" spacing={2} mt={4} mb={8}>
+        <img
+          src="/c4clogo.png"
+          alt="C4C Logo"
+          style={{ width: 50, height: 40 }}
+        />
+        <Typography variant="h4" sx={{ fontWeight: 'bold', color: 'white' }}>
+          Database | {getCurrentSemester()} {getCurrentYear()} Recruitment Cycle
+        </Typography>
+      </Stack>
+      <DataGrid
+        rows={data}
+        columns={RecruiterColumns}
+        checkboxSelection
+        disableRowSelectionOnClick
+        sx={{
+          border: 'none',
+          boxShadow: 'none',
+          backgroundColor: '#1E1E1E',
+          color: 'white',
+          '& .MuiDataGrid-columnHeaders': {
+            backgroundColor: '#1E1E1E',
+            borderBottom: 'none !important',
+            color: '#BDBDBD',
+            fontSize: '0.85rem',
+            boxShadow: 'none',
+          },
+          '& .MuiDataGrid-columnHeader': {
+            borderRight: 'none !important',
+            boxShadow: 'none',
+          },
+          '& .MuiDataGrid-columnHeaderTitle': {
+            fontWeight: 'bold',
+          },
+          '& .MuiDataGrid-cell': {
+            borderBottom: 'none !important',
+            borderRight: 'none !important',
+            color: 'white',
+            boxShadow: 'none',
+            outline: 'none !important',
+          },
+          '& .MuiDataGrid-row': {
+            borderBottom: 'none !important',
+            boxShadow: 'none',
+          },
+          '& .MuiDataGrid-row.Mui-selected': {
+            backgroundColor: 'purple',
+            '&:hover': {
+              backgroundColor: 'purple',
+            },
+          },
+          '& .MuiDataGrid-footerContainer': {
+            backgroundColor: '#1E1E1E',
+            borderTop: 'none !important',
+            color: '#BDBDBD',
+            boxShadow: 'none',
+          },
+          '& .MuiDataGrid-toolbarContainer': {
+            borderBottom: 'none !important',
+            boxShadow: 'none',
+          },
+          '& .MuiDataGrid-cell:focus, & .MuiDataGrid-columnHeader:focus': {
+            outline: 'none !important',
+            border: 'none !important',
+            boxShadow: 'none !important',
+          },
+        }}
+        initialState={{
+          pagination: {
+            paginationModel: { page: 0, pageSize: 5 },
+          },
+        }}
+        pageSizeOptions={[5, 10]}
+        onRowSelectionModelChange={(newRowSelectionModel) => {
+          setRowSelection(newRowSelectionModel);
+          if (
+            newRowSelectionModel.length > 0 &&
+            data?.[newRowSelectionModel?.[0] as number]
+          ) {
+            getApplication(data?.[newRowSelectionModel?.[0] as number]?.userId);
+          }
+        }}
+        rowSelectionModel={rowSelection}
+      />
+    </Container>
+  );
+}

--- a/apps/frontend/src/components/RecruiterView/Table.tsx
+++ b/apps/frontend/src/components/RecruiterView/Table.tsx
@@ -4,7 +4,7 @@ import { Application, ApplicationRow, Semester } from '@components/types';
 import { Container, Stack, Typography } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import { GridRowSelectionModel } from '@mui/x-data-grid/models/gridRowSelectionModel';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { RecruiterColumns } from './columns';
 
 export function RecruiterTable() {
@@ -22,8 +22,6 @@ export function RecruiterTable() {
     return TODAY.getFullYear();
   };
 
-  const isPageRendered = useRef<boolean>(false);
-
   const { token: accessToken } = useLoginContext();
   const [data, setData] = useState<ApplicationRow[]>([]);
   const [fullName, setFullName] = useState<string>('');
@@ -37,6 +35,7 @@ export function RecruiterTable() {
   const getApplication = async (userId: number) => {
     try {
       const application = await apiClient.getApplication(accessToken, userId);
+      console.log('Fetched application:', application);
       setSelectedApplication(application);
     } catch (error) {
       console.error('Error fetching application:', error);
@@ -64,12 +63,6 @@ export function RecruiterTable() {
     getFullName();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accessToken]);
-
-  useEffect(() => {
-    if (rowSelection.length > 0) {
-      setSelectedUserRow(data[rowSelection[0] as number]);
-    }
-  }, [rowSelection, data]);
 
   useEffect(() => {
     if (rowSelection.length > 0) {

--- a/apps/frontend/src/components/RecruiterView/Table.tsx
+++ b/apps/frontend/src/components/RecruiterView/Table.tsx
@@ -101,27 +101,27 @@ export function RecruiterTable() {
           color: 'white',
           '& .MuiDataGrid-columnHeaders': {
             backgroundColor: '#1E1E1E',
-            borderBottom: 'none !important',
+            borderBottom: 'none',
             color: '#BDBDBD',
             fontSize: '0.85rem',
             boxShadow: 'none',
           },
           '& .MuiDataGrid-columnHeader': {
-            borderRight: 'none !important',
+            borderRight: 'none',
             boxShadow: 'none',
           },
           '& .MuiDataGrid-columnHeaderTitle': {
             fontWeight: 'bold',
           },
           '& .MuiDataGrid-cell': {
-            borderBottom: 'none !important',
-            borderRight: 'none !important',
+            borderBottom: 'none',
+            borderRight: 'none',
             color: 'white',
             boxShadow: 'none',
-            outline: 'none !important',
+            outline: 'none',
           },
           '& .MuiDataGrid-row': {
-            borderBottom: 'none !important',
+            borderBottom: 'none',
             boxShadow: 'none',
           },
           '& .MuiDataGrid-row.Mui-selected': {
@@ -132,18 +132,18 @@ export function RecruiterTable() {
           },
           '& .MuiDataGrid-footerContainer': {
             backgroundColor: '#1E1E1E',
-            borderTop: 'none !important',
+            borderTop: 'none',
             color: '#BDBDBD',
             boxShadow: 'none',
           },
           '& .MuiDataGrid-toolbarContainer': {
-            borderBottom: 'none !important',
+            borderBottom: 'none',
             boxShadow: 'none',
           },
           '& .MuiDataGrid-cell:focus, & .MuiDataGrid-columnHeader:focus': {
-            outline: 'none !important',
-            border: 'none !important',
-            boxShadow: 'none !important',
+            outline: 'none',
+            border: 'none',
+            boxShadow: 'none',
           },
         }}
         initialState={{

--- a/apps/frontend/src/components/RecruiterView/columns.ts
+++ b/apps/frontend/src/components/RecruiterView/columns.ts
@@ -11,12 +11,12 @@ export const RecruiterColumns = [
   },
   {
     field: 'review',
-    headerName: 'Review',
+    headerName: 'Review Stage',
     width: 125,
   },
   {
     field: 'assignedRecruiters',
-    headerName: 'Assigned Recruiters',
+    headerName: 'Assigned to:',
     width: 200,
     renderCell: (params: any) => {
       const recruiters = params.value as Array<{

--- a/apps/frontend/src/components/RecruiterView/columns.ts
+++ b/apps/frontend/src/components/RecruiterView/columns.ts
@@ -1,0 +1,44 @@
+export const RecruiterColumns = [
+  {
+    field: 'name',
+    headerName: 'Name',
+    width: 200,
+  },
+  {
+    field: 'position',
+    headerName: 'Position',
+    width: 150,
+  },
+  {
+    field: 'review',
+    headerName: 'Review',
+    width: 125,
+  },
+  {
+    field: 'assignedRecruiters',
+    headerName: 'Assigned Recruiters',
+    width: 200,
+    renderCell: (params: any) => {
+      const recruiters = params.value as Array<{
+        firstName: string;
+        lastName: string;
+      }>;
+      if (!recruiters || recruiters.length === 0) {
+        return 'None Assigned';
+      }
+      return recruiters
+        .map((recruiter) => `${recruiter.firstName} ${recruiter.lastName}`)
+        .join(', ');
+    },
+  },
+  {
+    field: 'stage',
+    headerName: 'App Stage',
+    width: 150,
+  },
+  {
+    field: 'rating',
+    headerName: 'Rating',
+    width: 125,
+  },
+];

--- a/apps/frontend/src/components/types.ts
+++ b/apps/frontend/src/components/types.ts
@@ -33,6 +33,7 @@ type ApplicationRow = {
   reviewed: string;
   assignedTo: string[];
   stage: ApplicationStage;
+  step: ApplicationStep;
   rating: number | null;
   createdAt: Date;
   meanRatingAllReviews: number | null;

--- a/apps/frontend/src/components/types.ts
+++ b/apps/frontend/src/components/types.ts
@@ -12,6 +12,7 @@ enum ApplicationStep {
   REVIEWED = 'REVIEWED',
 }
 
+//
 enum ReviewStatus {
   UNASSIGNED = 'UNASSIGNED',
   ASSIGNED = 'ASSIGNED',

--- a/apps/frontend/src/components/types.ts
+++ b/apps/frontend/src/components/types.ts
@@ -20,7 +20,7 @@ enum Position {
   DESIGNER = 'DESIGNER',
 }
 
-enum ApplicationStep {
+enum ReviewStage {
   SUBMITTED = 'SUBMITTED',
   REVIEWED = 'REVIEWED',
 }
@@ -86,7 +86,7 @@ type Application = {
   semester: Semester;
   position: Position;
   stage: ApplicationStage;
-  step: ApplicationStep;
+  step: ReviewStage;
   review: ReviewStatus;
   response: Response[];
   numApps: number;
@@ -126,7 +126,7 @@ export {
   ApplicationRow,
   Application,
   ApplicationStage,
-  ApplicationStep,
+  ReviewStage,
   ReviewStatus,
   Position,
   Response,

--- a/apps/frontend/src/components/types.ts
+++ b/apps/frontend/src/components/types.ts
@@ -7,6 +7,11 @@ enum ApplicationStage {
   REJECTED,
 }
 
+enum ApplicationStep {
+  SUBMITTED = 'SUBMITTED',
+  REVIEWED = 'REVIEWED',
+}
+
 enum ReviewStatus {
   UNASSIGNED = 'UNASSIGNED',
   ASSIGNED = 'ASSIGNED',
@@ -20,11 +25,6 @@ enum Position {
   DESIGNER = 'DESIGNER',
 }
 
-enum ApplicationStep {
-  SUBMITTED = 'SUBMITTED',
-  REVIEWED = 'REVIEWED',
-}
-
 type ApplicationRow = {
   id: number;
   userId: number;
@@ -32,7 +32,7 @@ type ApplicationRow = {
   position: Position;
   reviewed: string;
   assignedTo: string[];
-  step: ApplicationStep;
+  review: ReviewStatus;
   stage: ApplicationStage;
   rating: number | null;
   createdAt: Date;

--- a/apps/frontend/src/components/types.ts
+++ b/apps/frontend/src/components/types.ts
@@ -14,15 +14,15 @@ enum ReviewStatus {
   REVIEWED = 'REVIEWED',
 }
 
-enum ApplicationStep {
-  SUBMITTED = 'SUBMITTED',
-  REVIEWED = 'REVIEWED',
-}
-
 enum Position {
   DEVELOPER = 'DEVELOPER',
   PM = 'PRODUCT_MANAGER',
   DESIGNER = 'DESIGNER',
+}
+
+enum ApplicationStep {
+  SUBMITTED = 'SUBMITTED',
+  REVIEWED = 'REVIEWED',
 }
 
 type ApplicationRow = {
@@ -32,8 +32,8 @@ type ApplicationRow = {
   position: Position;
   reviewed: string;
   assignedTo: string[];
-  stage: ApplicationStage;
   step: ApplicationStep;
+  stage: ApplicationStage;
   rating: number | null;
   createdAt: Date;
   meanRatingAllReviews: number | null;

--- a/apps/frontend/src/containers/applications.tsx
+++ b/apps/frontend/src/containers/applications.tsx
@@ -23,6 +23,7 @@ const Applications: React.FC = () => {
   }, []);
 
   if (!currentUser) return <div>Loading...</div>;
+  else console.log('Current user is ', currentUser);
 
   return (
     <>

--- a/apps/frontend/src/containers/applications.tsx
+++ b/apps/frontend/src/containers/applications.tsx
@@ -1,9 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ApplicationTable } from '@components/ApplicationTables';
 import { RecruiterTable } from '@components/RecruiterView/Table';
+import { User } from '@components/types';
+import apiClient from '@api/apiClient';
+import useLoginContext from '@components/LoginPage/useLoginContext';
 
 const Applications: React.FC = () => {
-  return <RecruiterTable />;
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const { token: accessToken } = useLoginContext();
+
+  const getUser = async () => {
+    try {
+      const currentUser = await apiClient.getUser(accessToken);
+      setCurrentUser(currentUser);
+    } catch (error) {
+      console.error('Error fetching User:', error);
+    }
+  };
+
+  if (!currentUser) return <div>Loading...</div>;
+
+  return (
+    <>
+      {currentUser.status === 'Recruiter' ? (
+        <RecruiterTable />
+      ) : (
+        <ApplicationTable />
+      )}
+    </>
+  );
 };
 
 export default Applications;

--- a/apps/frontend/src/containers/applications.tsx
+++ b/apps/frontend/src/containers/applications.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { ApplicationTable } from '@components/ApplicationTables';
+import { RecruiterTable } from '@components/RecruiterView/Table';
 
 const Applications: React.FC = () => {
-  return <ApplicationTable />;
+  return <RecruiterTable />;
 };
 
 export default Applications;

--- a/apps/frontend/src/containers/applications.tsx
+++ b/apps/frontend/src/containers/applications.tsx
@@ -18,6 +18,10 @@ const Applications: React.FC = () => {
     }
   };
 
+  useEffect(() => {
+    getUser();
+  }, []);
+
   if (!currentUser) return <div>Loading...</div>;
 
   return (

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -22,7 +22,7 @@ html, body {
 .MuiDataGrid-root {
   background-color: #2a2a2a !important;
   color: white !important;
-  border: 1px solid #404040 !important;
+  border: 1px transparent #404040 !important;
 }
 
 .MuiDataGrid-cell {


### PR DESCRIPTION
### ℹ️ Issue

Closes #150 

### 📝 Description

Copied over a lot of the elements from the previous Application table but with only the columns that were present in the Figma design corresponding to this ticket. Added the logic for the default table to switch to whatever position the user viewing is at. For example, if the user is a recruiter, they will automatically see the recruiter table while everyone else sees the default table. 

### ✔️ Verification

I added a mock recruiter and several applicants. The one assigned to the recruiter only showed up on the table. 

<img width="1142" height="379" alt="Screenshot 2025-08-26 at 11 00 46 PM" src="https://github.com/user-attachments/assets/9dc141f5-842b-4c28-972e-aa8bc7c90e14" />

<img width="450" height="143" alt="Screenshot 2025-08-26 at 10 50 29 PM" src="https://github.com/user-attachments/assets/b7016559-e69c-42c2-b28e-3cd4b861b30d" />


### 🏕️ (Optional) Future Work / Notes

Not sure if it was just my branch but fetching the assigned recruiter may not work properly. That field showed up as "None assigned" even though the application that showed up was assigned to the current user (which wouldn't have showed up in the first place).