### PR TITLE
Fixed issue #179

### DIFF
--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -20,6 +20,7 @@ import { UserStatus } from '../users/types';
 import { Position, ApplicationStage, ReviewStage, Semester } from './types';
 import { GetAllApplicationResponseDTO } from './dto/get-all-application.response.dto';
 import { AssignedRecruiterDTO } from './dto/get-application.response.dto';
+import { forEach } from 'lodash';
 
 @Injectable()
 export class ApplicationsService {
@@ -140,8 +141,7 @@ export class ApplicationsService {
       );
     }
 
-    // Update the assignedRecruiterIds field
-    application.assignedRecruiterIds = recruiterIds;
+    application.assignedRecruiterIds = [...new Set(recruiterIds)];
     await this.applicationsRepository.save(application);
   }
 


### PR DESCRIPTION
ℹ️ Issue
Closes [#179](https://github.com/Code-4-Community/c4c-ops/issues/179)
📝 Description
<img width="1355" height="456" alt="Screenshot 2025-10-06 at 6 23 17 PM" src="https://github.com/user-attachments/assets/a42a2096-bd3c-4fa9-b941-cb897d72546d" />

Previously, when adding a new recruiter to an application, the other recruiters were erased. We changed this so that you can add new recruiters without messing up the old ones and without adding duplicates.
Was setting the given recruiterIds variable to the new field instead of appending it. 
✔️ Verification
Local testing, adding multiple accounts to pgadmin to test if we can add and remove effectively.