### PR TITLE
Added logic so that all recruiters must submit reviews before stage c…

### DIFF
--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -404,10 +404,7 @@ export class ApplicationsService {
     const allApplicationsDto = await Promise.all(
       applications.map(async (app) => {
         const ratings = this.calculateAllRatings(app.reviews);
-        const stageProgress = this.determineStageProgress(
-          app.stage,
-          app.reviews,
-        );
+            const stageProgress = this.determineStageProgress(app, app.reviews);
         const assignedRecruiters =
           await this.getAssignedRecruitersForApplication(app);
 
@@ -493,10 +490,14 @@ export class ApplicationsService {
    * A stage is considered COMPLETED if it has been reviewed
    * Terminal stages (ACCEPTED/REJECTED) are always COMPLETED
    */
-  private determineStageProgress(
-    stage: ApplicationStage,
-    reviews: any[],
-  ): StageProgress {
+  /**
+   * A stage is considered COMPLETED only when all assigned recruiters have
+   * submitted a review for that stage. If no recruiters are assigned, the
+   * stage remains PENDING even if admins or others submit reviews.
+   */
+  private determineStageProgress(app: Application, reviews: any[]): StageProgress {
+    const stage = app.stage;
+
     // Terminal stages are always completed
     if (
       stage === ApplicationStage.ACCEPTED ||
@@ -505,9 +506,26 @@ export class ApplicationsService {
       return StageProgress.COMPLETED;
     }
 
-    // Check if current stage has been reviewed
-    const stageReviewed = reviews.some((review) => review.stage === stage);
-    return stageReviewed ? StageProgress.COMPLETED : StageProgress.PENDING;
+    const assignedRecruiterIds = app.assignedRecruiterIds || [];
+
+    // If there are no assigned recruiters, the stage should not progress
+    if (assignedRecruiterIds.length === 0) {
+      return StageProgress.PENDING;
+    }
+
+    // Collect reviewer IDs who have submitted a review for the current stage
+    const reviewerIdsForStage = new Set(
+      reviews
+        .filter((review) => review.stage === stage)
+        .map((review) => review.reviewerId),
+    );
+
+    // Check that every assigned recruiter has submitted a review for this stage
+    const allAssignedReviewed = assignedRecruiterIds.every((id) =>
+      reviewerIdsForStage.has(id),
+    );
+
+    return allAssignedReviewed ? StageProgress.COMPLETED : StageProgress.PENDING;
   }
 
   /**


### PR DESCRIPTION
### ℹ️ Issue

Closes #199 

### 📝 Description

Updated: applications.service.ts
Replaced the previous simple "any review for the stage" check with logic that:
Returns COMPLETED only if every assignedRecruiterId has a review for the current stage.
Returns PENDING if assignedRecruiterIds is empty.
Updated callers to pass the Application object into the helper that determines stage progress.

### Verification:

TBD